### PR TITLE
feat(bindings.amqp): support env variables for connection string

### DIFF
--- a/connectors/bindings.amqp/readme.md
+++ b/connectors/bindings.amqp/readme.md
@@ -14,7 +14,7 @@ Well-known annotation shortcut `amqp` is available.
 # context.toa.yaml
 annotations:
   "@toa.io/bindings.amqp":
-    system: url0          # the runtime 
+    system: url0          # the runtime
     default: url1         # all undeclared
     dummies: url2         # namespace-wide
     dummies.dummy1: url  # component exclusive
@@ -46,9 +46,21 @@ amqp:
 annotations:
   "@toa.io/bindings.amqp":
     default: url1
-``` 
+```
 
 ```yaml
 # context.toa.yaml
 amqp: url1
-``` 
+```
+
+### Environment Variables
+
+Then Connection string may contain `environment` variable placeholders.
+
+```yaml
+# manifest.toa.yaml
+amqp:
+  foo@dev: amqp://stage${STAGE_NUMBER}.stages.com:5672
+```
+
+This is only usable in local development environment.

--- a/connectors/generics.amqp/source/connector.js
+++ b/connectors/generics.amqp/source/connector.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { shards } = require('@toa.io/generic')
+const { shards, echo } = require('@toa.io/generic')
 const { Pointer } = require('@toa.io/pointer')
 const { Communication } = require('./communication')
 
@@ -11,7 +11,8 @@ const { Communication } = require('./communication')
  */
 const connector = (prefix, locator) => {
   const pointer = new Pointer(prefix, locator, OPTIONS)
-  const references = shards(pointer.reference)
+  const reference = echo(pointer.reference)
+  const references = shards(reference)
 
   return new Communication(references)
 }

--- a/connectors/generics.amqp/test/connector.test.js
+++ b/connectors/generics.amqp/test/connector.test.js
@@ -71,3 +71,23 @@ it('should parse ranges', async () => {
 
   expect(Communication).toHaveBeenCalledWith(expected)
 })
+
+it('should parse env variables', async () => {
+  jest.clearAllMocks()
+
+  const base = generate()
+  const varName = generate({ charset: 'abcDerWsxzF', length: 6 })
+  const varValue = generate()
+
+  process.env[varName] = varValue
+
+  const reference = `\${${varName}}.${base}`
+
+  Pointer.mockImplementation(() => ({ reference }))
+
+  const expected = `${varValue}.${base}`
+
+  comm = connector(prefix, locator)
+
+  expect(Communication).toHaveBeenCalledWith([expected])
+})


### PR DESCRIPTION
Close #382 