### PR TITLE
chore: commit VSCode project-specific config and extensions recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 node_modules/
 transpiled/
-.vscode
 .idea
 lerna-debug.log
 .DS_Store
 *.tsbuildinfo
 **/.env
+.eslintcache

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "alexkrechik.cucumberautocomplete",
+    "joshbolduc.commitlint",
+    "redhat.vscode-yaml",
+    "ms-azuretools.vscode-docker",
+    "balrog994.cucumber-test-runner",
+    "orta.vscode-jest",
+    "github.vscode-pull-request-github",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+  "prettier.enable": false, // this project is using `standard` for formatting, so disabling prettier
+  "eslint.format.enable": true,
+  "jest.autoRun": "off",
+  "[javascript][typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+  },
+  "eslint.useESLintClass": true,
+  "eslint.options": {
+    "cache": true,
+    "reportUnusedDisableDirectives": "error"
+  },
+  "eslint.workingDirectories": [
+    {
+      "mode": "auto"
+    }
+  ],
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/transpiled": true
+  },
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/node_modules/**": true,
+    "**/transpiled/**": true
+  },
+}


### PR DESCRIPTION
Adding `.vscode` to gitignore is wrong as it only makes onboarding slower. Particularly this project are using some specific conventions that are not very common in the Javascript world (like using `standard` via ESLint for code formatting rather than using most widely adopted Prettier) and such configuration may save contributors from initial chore.

In additional this project is using CucumberJs scenarios language that is not supported out-of-box in VSCode and requiring special extension that we are adding in this PR into workspace recommended extensions.