### PR TITLE
chore: remove `fund=false`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
-fund=false
 audit=false
 sign-git-commit=true
 sign-git-tag=true


### PR DESCRIPTION
Disabling `fund` in a public open source project may be seen as an act of disrespect to other open source developers' work on which this project is partially based.

A developer can always set their own preference locally by using `npm config -L global set fund false`.