### PR TITLE
chore: remove fs-extra usage

### DIFF
--- a/extensions/exposition/features/steps/Workspace.ts
+++ b/extensions/exposition/features/steps/Workspace.ts
@@ -1,17 +1,17 @@
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
-import { mkdtemp, copy } from 'fs-extra'
+import { tmpdir, devNull } from 'node:os'
+import { mkdtemp, cp } from 'node:fs/promises'
 import * as yaml from '@toa.io/yaml'
 
 export class Workspace {
-  private root: string = devnull
+  private root: string = devNull
 
   public static exists
   (_0: unknown, _1: unknown, descriptor: PropertyDescriptor): PropertyDescriptor {
     const method = descriptor.value
 
     descriptor.value = async function (this: Workspace, ...args: any[]): Promise<any> {
-      if (this.root === devnull) this.root =
+      if (this.root === devNull) this.root =
         await mkdtemp(join(tmpdir(), Math.random().toString(36).slice(2)))
 
       return method.apply(this, args)
@@ -25,7 +25,7 @@ export class Workspace {
     const source = join(__dirname, 'components', name)
     const target = join(this.root, name)
 
-    await copy(source, target)
+    await cp(source, target, { force: true, recursive: true })
 
     if (patch !== undefined)
       await this.patchManifest(target, patch)
@@ -39,5 +39,3 @@ export class Workspace {
     await yaml.patch(path, patch)
   }
 }
-
-const devnull = '/dev/null'

--- a/extensions/storages/package.json
+++ b/extensions/storages/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@toa.io/streams": "0.24.0-alpha.18",
-    "@types/fs-extra": "11.0.3",
     "dotenv": "16.3.1"
   },
   "dependencies": {
@@ -35,7 +34,6 @@
     "@toa.io/generic": "0.20.0-alpha.2",
     "@toa.io/http": "0.24.0-alpha.18",
     "error-value": "0.3.0",
-    "fs-extra": "11.1.1",
     "matchacho": "0.3.5",
     "msgpackr": "1.9.9"
   }

--- a/extensions/storages/source/providers/FileSystem.ts
+++ b/extensions/storages/source/providers/FileSystem.ts
@@ -1,46 +1,48 @@
 import { type Readable } from 'node:stream'
 import { dirname, join } from 'node:path'
-import { createReadStream } from 'node:fs'
 import fs from 'node:fs/promises'
-import fse from 'fs-extra'
+import { fileURLToPath } from 'node:url'
+import assert from 'node:assert'
 import { type Provider } from '../Provider'
 
 export class FileSystem implements Provider {
   protected readonly path: string
 
   public constructor (url: URL) {
-    if (url.host !== '')
-      throw new Error('File system URL must not contain host')
+    assert.equal(url.protocol, 'file:', `Invalid FileSystem URL: ${url.toString()}`)
 
-    this.path = url.pathname
+    this.path = fileURLToPath(url)
   }
 
   public async get (path: string): Promise<Readable | null> {
-    path = join(this.path, path)
+    try {
+      const fd = await fs.open(join(this.path, path))
 
-    if (!await fse.exists(path))
-      return null
+      return fd.createReadStream()
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return null
 
-    return createReadStream(path)
+      throw err
+    }
   }
 
   public async put (rel: string, filename: string, stream: Readable): Promise<void> {
     const dir = join(this.path, rel)
     const path = join(dir, filename)
 
-    await fse.ensureDir(dir)
+    await fs.mkdir(dirname(path), { recursive: true })
     await fs.writeFile(path, stream)
   }
 
   public async delete (path: string): Promise<void> {
-    await fse.remove(join(this.path, path))
+    await fs.rm(join(this.path, path), { recursive: true, force: true })
   }
 
   public async move (from: string, to: string): Promise<void> {
     from = join(this.path, from)
     to = join(this.path, to)
 
-    await fse.ensureDir(dirname(to))
+    await fs.mkdir(dirname(to), { recursive: true })
     await fs.rename(from, to)
   }
 }

--- a/extensions/storages/source/providers/Temporary.ts
+++ b/extensions/storages/source/providers/Temporary.ts
@@ -1,14 +1,13 @@
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import assert from 'node:assert'
+import { pathToFileURL } from 'node:url'
 
 import { FileSystem } from './FileSystem'
 
 export class Temporary extends FileSystem {
-  protected override readonly path: string
-
   public constructor (url: URL) {
-    super(url)
-
-    this.path = join(tmpdir(), url.pathname)
+    assert.equal(url.protocol, 'tmp:', `Invalid Temporary URL: ${url.toString()}`)
+    super(pathToFileURL(join(tmpdir(), url.pathname)))
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -329,13 +329,11 @@
         "@toa.io/generic": "0.20.0-alpha.2",
         "@toa.io/http": "0.24.0-alpha.18",
         "error-value": "0.3.0",
-        "fs-extra": "11.1.1",
         "matchacho": "0.3.5",
         "msgpackr": "1.9.9"
       },
       "devDependencies": {
         "@toa.io/streams": "0.24.0-alpha.18",
-        "@types/fs-extra": "11.0.3",
         "dotenv": "16.3.1"
       }
     },
@@ -4500,16 +4498,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*",
         "@types/send": "*"
-      }
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.3.tgz",
-      "integrity": "sha512-sF59BlXtUdzEAL1u0MSvuzWd7PdZvZEtnaVkzX5mjpdWTJ8brG0jUqve3jPCzSzvAKKMHTG8F8o/WMQLtleZdQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/jsonfile": "*",
-        "@types/node": "*"
       }
     },
     "node_modules/@types/graceful-fs": {


### PR DESCRIPTION
`fs-extra` is just a legacy compatibility layer that is redundant and performance degrading in case if we are targeting Node 18.x (and we do).

Several functions used from `fs-extra` (such as `mkdtemp`) are just direct re-export of Node `fs` (but with worst error stack trace), while others have direct native equivalent.

We also fixing a bad pattern (even [mentioned in the Node.js documentation](https://nodejs.org/docs/latest-v18.x/api/fs.html#fspromisesaccesspath-mode)) of using `exist` check before opening file - this is prone to race conditions and we just need to do `fs.open` directly.

We also using standard Node.js functions to work with `file:` URLs (`fileURLToPath` / `pathToFileURL` from `node:url`) rather than improvised checks.