### PR TITLE
fix: don't import global values from 'buffer' module

### DIFF
--- a/extensions/exposition/components/identity.basic/source/authenticate.ts
+++ b/extensions/exposition/components/identity.basic/source/authenticate.ts
@@ -1,4 +1,3 @@
-import { atob } from 'buffer'
 import { compare } from 'bcryptjs'
 import { type Query, type Maybe } from '@toa.io/types'
 import { Err } from 'error-value'

--- a/extensions/exposition/source/HTTP/Server.fixtures.ts
+++ b/extensions/exposition/source/HTTP/Server.fixtures.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer'
 import { Readable } from 'stream'
 import type { IncomingMessage } from './messages'
 import type * as http from 'node:http'


### PR DESCRIPTION
Both `atob` and `Buffer` are available as globals in Node 16+. While they can be imported from `node:buffer` keeping them as import from just `buffer` is dangerous because there is NPM-published [buffer](https://www.npmjs.com/package/buffer) module that is available in this project `package-lock.json`.

This PR switches to use globally exposed functions.