### PR TITLE
chore: convert to proper Typescript composite project

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -66,11 +66,21 @@ overrides:
         - error
         - always
         - null: always
+      '@typescript-eslint/no-unsafe-argument': warn
+      '@typescript-eslint/non-nullable-type-assertion-style': warn
+      '@typescript-eslint/unbound-method': warn
 
+  - files: ["*.test.ts", "**/test/**"]
+    extends: 'plugin:@typescript-eslint/disable-type-checked'
+    env:
+      jest: true
+  - files: ['**/features/**/*.ts']
+    extends: 'plugin:@typescript-eslint/disable-type-checked'
+    rules:
+       '@typescript-eslint/prefer-nullish-coalescing': 'off'
+       '@typescript-eslint/strict-boolean-expressions': 'off'
 parserOptions:
-  project: ./tsconfig.json
-env:
-  jest: true
+  project: true
 ignorePatterns:
   - '*.d.ts'
   - '*.js'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,12 +19,13 @@
     }
   ],
   "search.exclude": {
-    "**/node_modules": true,
-    "**/transpiled": true
+    "**/node_modules/**": true,
+    "**/transpiled/**": true
   },
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/node_modules/**": true,
     "**/transpiled/**": true
   },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/connectors/bindings.amqp/tsconfig.json
+++ b/connectors/bindings.amqp/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/connectors/tsconfig.json
+++ b/connectors/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "bindings.amqp"
+    }
+  ]
+}

--- a/extensions/configuration/tsconfig.json
+++ b/extensions/configuration/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/extensions/exposition/components/identity.basic/tsconfig.json
+++ b/extensions/exposition/components/identity.basic/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./operations",
+    "rootDir": "./source"
   },
   "include": [
     "source"

--- a/extensions/exposition/components/identity.roles/tsconfig.json
+++ b/extensions/exposition/components/identity.roles/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./operations",
+    "rootDir": "./source"
   },
   "include": [
     "source"

--- a/extensions/exposition/components/identity.tokens/tsconfig.json
+++ b/extensions/exposition/components/identity.tokens/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./operations",
+    "rootDir": "./source"
   },
   "include": [
     "source"

--- a/extensions/exposition/features/steps/tsconfig.json
+++ b/extensions/exposition/features/steps/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "outDir": "/dev/null",
+    "noEmit": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true

--- a/extensions/exposition/package.json
+++ b/extensions/exposition/package.json
@@ -37,10 +37,10 @@
   },
   "scripts": {
     "test": "jest",
-    "transpile": "npx tsc && npm run transpile:basic && npm run transpile:tokens && npm run transpile:roles",
-    "transpile:basic": "npx tsc -p ./components/identity.basic",
-    "transpile:tokens": "npx tsc -p ./components/identity.tokens",
-    "transpile:roles": "npx tsc -p ./components/identity.roles",
+    "transpile": "tsc --build",
+    "transpile:basic": "tsc -p ./components/identity.basic",
+    "transpile:tokens": "tsc -p ./components/identity.tokens",
+    "transpile:roles": "tsc -p ./components/identity.roles",
     "features": "npx cucumber-js"
   },
   "devDependencies": {

--- a/extensions/exposition/tsconfig.json
+++ b/extensions/exposition/tsconfig.json
@@ -1,12 +1,25 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./transpiled"
+    "composite": true,
+    "outDir": "./transpiled",
+    "rootDir": "./source"
   },
   "include": [
     "source"
   ],
   "exclude": [
     "**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "components/identity.basic"
+    },
+    {
+      "path": "components/identity.tokens"
+    },
+    {
+      "path": "components/identity.roles"
+    }
   ]
 }

--- a/extensions/origins/tsconfig.json
+++ b/extensions/origins/tsconfig.json
@@ -1,10 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./transpiled"
+    "composite": true,
+    "outDir": "./transpiled",
   },
   "include": [
-    "source"
+    "source",
+    "source/protocols/http/.aspect/**/*" // TS ignores .dot files by default
   ],
   "exclude": [
     "**/*.test.ts"

--- a/extensions/realtime/components/streams/source/create.ts
+++ b/extensions/realtime/components/streams/source/create.ts
@@ -10,7 +10,7 @@ export class Effect implements Operation {
     context.state.streams = this.streams
   }
 
-  public async execute (input: Input, context: Context): Promise<Readable> {
+  public async execute (input: Input, _context: Context): Promise<Readable> {
     const key = input.key
 
     if (!this.streams.has(key))

--- a/extensions/realtime/components/streams/tsconfig.json
+++ b/extensions/realtime/components/streams/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./operations",
   },
   "include": [

--- a/extensions/realtime/features/steps/tsconfig.json
+++ b/extensions/realtime/features/steps/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "outDir": "/dev/null",
+    "noEmit": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
   }
 }

--- a/extensions/realtime/package.json
+++ b/extensions/realtime/package.json
@@ -21,7 +21,7 @@
     "testEnvironment": "node"
   },
   "scripts": {
-    "transpile": "npx tsc && npx tsc -p ./components/streams",
+    "transpile": "tsc --build",
     "features": "npx cucumber-js"
   }
 }

--- a/extensions/realtime/tsconfig.json
+++ b/extensions/realtime/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [
@@ -8,5 +9,10 @@
   ],
   "exclude": [
     "**/*.test.ts"
+  ],
+  "references": [
+    {
+      "path": "components/streams"
+    }
   ]
 }

--- a/extensions/stash/source/Aspect.ts
+++ b/extensions/stash/source/Aspect.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error -- this implementation should be replaced with official @redis libs
 import Redlock from 'redlock-temp-fix'
 import { encode, decode } from 'msgpackr'
 import { Connector, type extensions } from '@toa.io/core'

--- a/extensions/stash/tsconfig.json
+++ b/extensions/stash/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/extensions/storages/source/providers/S3.test.ts
+++ b/extensions/storages/source/providers/S3.test.ts
@@ -49,9 +49,11 @@ describe('S3 storage provider', () => {
   })
 
   test('should remove folder with all files', async () => {
-    const headHandler = jest.fn().mockReturnValue(HttpResponse.xml('', { status: 404 }))
+    const headHandler = jest.fn().mockReturnValue(new Response('', {
+      status: 404, headers: { 'content-type': 'application/xml' }
+    }))
 
-    const listHandler = jest.fn().mockReturnValueOnce(HttpResponse.xml(`
+    const listHandler = jest.fn().mockReturnValueOnce(new Response(`
     <ListBucketResult>
       <NextContinuationToken>someToken</NextContinuationToken>
       <KeyCount>1001</KeyCount>
@@ -62,8 +64,8 @@ describe('S3 storage provider', () => {
       </Contents>
     </ListBucketResult>
     `, {
-      status: 200
-    })).mockReturnValueOnce(HttpResponse.xml(`
+      status: 200, headers: { 'content-type': 'application/xml' }
+    })).mockReturnValueOnce(new Response(`
     <ListBucketResult>
       <KeyCount>1001</KeyCount>
       <MaxKeys>1000</MaxKeys>
@@ -75,10 +77,10 @@ describe('S3 storage provider', () => {
       </Contents>
     </ListBucketResult>
     `, {
-      status: 200
+      status: 200, headers: { 'content-type': 'application/xml' }
     }))
 
-    const deleteHandler = jest.fn().mockReturnValue(HttpResponse.xml(`
+    const deleteHandler = jest.fn().mockReturnValue(new Response(`
     <DeleteResult>
       <Deleted>
         <Key>happy_face1.jpg</Key>
@@ -91,7 +93,7 @@ describe('S3 storage provider', () => {
       </Deleted>
     </DeleteResult>
     `, {
-      status: 200
+      status: 200, headers: { 'content-type': 'application/xml' }
     }))
 
     s3endpoint.use(http.head(`${S3_ENDPOINT}/some/absolute/path_to_remove`,
@@ -110,13 +112,14 @@ describe('S3 storage provider', () => {
   test('should be able to upload a file to S3', async () => {
     const body = Readable.from('test content')
 
-    const handler = jest.fn().mockReturnValue(HttpResponse.xml('', {
+    const handler = jest.fn().mockReturnValue(new Response('', {
       status: 200,
       headers: {
         ETag: 'test-etag',
         'x-amz-id-2': 'test_id_2',
         'x-amz-request-id': 'test_request_id',
-        Server: 'AmazonS3'
+        Server: 'AmazonS3',
+        'content-type': 'application/xml'
       }
     }))
 

--- a/extensions/storages/tsconfig.json
+++ b/extensions/storages/tsconfig.json
@@ -1,12 +1,15 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./transpiled"
+    "composite": true,
+    "outDir": "./transpiled",
+    "rootDir": "./source"
   },
   "include": [
     "source"
   ],
   "exclude": [
+    "source/test/",
     "**/*.test.ts"
   ]
 }

--- a/extensions/tsconfig.json
+++ b/extensions/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "configuration"
+    },
+    {
+      "path": "storages"
+    },
+    {
+      "path": "exposition"
+    },
+    {
+      "path": "origins"
+    },
+    {
+      "path": "realtime"
+    },
+    {
+      "path": "stash"
+    }
+  ]
+}

--- a/libraries/command/source/index.test.ts
+++ b/libraries/command/source/index.test.ts
@@ -34,7 +34,7 @@ const stderr = {
   pipe: jest.fn()
 }
 
-const exec = jest.fn((command, callback) => {
+const exec = jest.fn((_command, callback) => {
   setImmediate(() => {
     callback(null)
   })

--- a/libraries/command/tsconfig.json
+++ b/libraries/command/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/libraries/http/source/Agent.ts
+++ b/libraries/http/source/Agent.ts
@@ -83,17 +83,17 @@ export class Agent {
     const request = {
       method,
       headers,
-      body: stream as unknown as ReadableStream,
-      duplex: 'half'
+      body: stream
     }
 
     try {
       const response = await fetch(href, request)
 
       this.response = await http.parse.response(response)
-    } catch (e: any) {
+    } catch (e) {
       console.error(e)
-      console.error(e.cause)
+
+      if (e instanceof Error) console.error(e.cause)
 
       throw e
     }

--- a/libraries/http/tsconfig.json
+++ b/libraries/http/tsconfig.json
@@ -1,9 +1,14 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./transpiled"
+    "composite": true,
+    "outDir": "./transpiled",
+    "rootDir": "./source",
   },
   "include": [
-    "source"
+    "source/"
+  ],
+  "exclude": [
+    "**/*.test.ts"
   ]
 }

--- a/libraries/kubernetes/tsconfig.json
+++ b/libraries/kubernetes/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/libraries/pointer/tsconfig.json
+++ b/libraries/pointer/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/libraries/streams/tsconfig.json
+++ b/libraries/streams/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [

--- a/libraries/tsconfig.json
+++ b/libraries/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "files": [],
+  "references": [
+    {
+      "path": "command"
+    },
+    {
+      "path": "http"
+    },
+    {
+      "path": "kubernetes"
+    },
+    {
+      "path": "pointer"
+    },
+    {
+      "path": "streams"
+    }
+  ]
+}

--- a/libraries/tsconfig.json
+++ b/libraries/tsconfig.json
@@ -6,6 +6,12 @@
   "files": [],
   "references": [
     {
+      "path": "streams"
+    },
+    {
+      "path": "pointer"
+    },
+    {
       "path": "command"
     },
     {
@@ -14,11 +20,5 @@
     {
       "path": "kubernetes"
     },
-    {
-      "path": "pointer"
-    },
-    {
-      "path": "streams"
-    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,13 +39,11 @@
         "randomstring": "1.3.0",
         "testcontainers": "10.2.2",
         "ts-jest": "29.1.0",
-        "ts-node": "10.9.1"
+        "ts-node": "10.9.1",
+        "typescript": "~5.3.3"
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "^4.9.5"
       }
     },
     "connectors/bindings.amqp": {
@@ -113,18 +111,6 @@
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5.2.2"
-      }
-    },
-    "connectors/bridges.node/node_modules/typescript": {
-      "version": "5.3.2",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "connectors/storages.mongodb": {
@@ -218,18 +204,6 @@
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5.2.2"
-      }
-    },
-    "extensions/exposition/node_modules/typescript": {
-      "version": "5.3.2",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "extensions/origins": {
@@ -339,18 +313,6 @@
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5.2.2"
-      }
-    },
-    "extensions/storages/node_modules/typescript": {
-      "version": "5.3.2",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "libraries/command": {
@@ -2097,6 +2059,19 @@
       },
       "engines": {
         "node": ">=v12"
+      }
+    },
+    "node_modules/@commitlint/load/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@commitlint/message": {
@@ -15391,14 +15366,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "license": "Apache-2.0",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -16052,18 +16028,6 @@
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^5.2.2"
-      }
-    },
-    "runtime/core/node_modules/typescript": {
-      "version": "5.3.2",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "runtime/norm": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,20 +26,22 @@
         "@types/jest": "29.5.3",
         "@types/node": "20.8.10",
         "@types/randomstring": "1.1.8",
+        "@typescript-eslint/eslint-plugin": "^6.17.0",
+        "@typescript-eslint/parser": "^6.17.0",
         "clone-deep": "4.0.1",
         "cucumber-tsflow": "4.2.1",
         "dotenv": "16.0.3",
-        "eslint-config-standard-with-typescript": "38.0.0",
+        "eslint-config-standard-with-typescript": "43.0.0",
         "execa": "5.1.1",
         "husky": "8.0.3",
         "jest": "29.5.0",
         "jest-diff": "29.6.2",
         "knex": "2.4.2",
-        "msw": "2.0.11",
+        "msw": "2.0.13",
         "randomstring": "1.3.0",
         "testcontainers": "10.2.2",
         "ts-jest": "29.1.0",
-        "ts-node": "10.9.1",
+        "ts-node": "10.9.2",
         "typescript": "~5.3.3"
       },
       "engines": {
@@ -2456,7 +2458,6 @@
       "version": "4.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -2471,7 +2472,6 @@
       "version": "4.10.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -4363,9 +4363,9 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -4431,9 +4431,9 @@
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+      "dev": true
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -4512,16 +4512,16 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
+      "integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.12.0",
-        "@typescript-eslint/type-utils": "6.12.0",
-        "@typescript-eslint/utils": "6.12.0",
-        "@typescript-eslint/visitor-keys": "6.12.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/type-utils": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -4550,7 +4550,6 @@
       "version": "6.0.0",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4562,7 +4561,6 @@
       "version": "7.5.4",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4576,18 +4574,18 @@
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
       "version": "4.0.0",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
+      "integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.12.0",
-        "@typescript-eslint/types": "6.12.0",
-        "@typescript-eslint/typescript-estree": "6.12.0",
-        "@typescript-eslint/visitor-keys": "6.12.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4607,12 +4605,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+      "integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.12.0",
-        "@typescript-eslint/visitor-keys": "6.12.0"
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -4623,13 +4622,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+      "integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.12.0",
-        "@typescript-eslint/utils": "6.12.0",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -4650,9 +4649,10 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+      "integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
       },
@@ -4662,15 +4662,17 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+      "integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "6.12.0",
-        "@typescript-eslint/visitor-keys": "6.12.0",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
         "semver": "^7.5.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -4687,10 +4689,20 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4698,10 +4710,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4714,21 +4742,22 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+      "integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.12.0",
-        "@typescript-eslint/types": "6.12.0",
-        "@typescript-eslint/typescript-estree": "6.12.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -4744,9 +4773,9 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4756,9 +4785,9 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4771,16 +4800,17 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "ISC",
-      "peer": true
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.12.0",
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+      "integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.12.0",
+        "@typescript-eslint/types": "6.18.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -5179,8 +5209,9 @@
     },
     "node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -6655,8 +6686,9 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -7047,15 +7079,16 @@
       }
     },
     "node_modules/eslint-config-standard-with-typescript": {
-      "version": "38.0.0",
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-43.0.0.tgz",
+      "integrity": "sha512-AT0qK01M5bmsWiE3UZvaQO5da1y1n6uQckAKqGNe6zPW5IOzgMLXZxw77nnFm+C11nxAZXsCPrbsgJhSrGfX6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/parser": "^6.1.0",
+        "@typescript-eslint/parser": "^6.4.0",
         "eslint-config-standard": "17.1.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^6.1.0",
+        "@typescript-eslint/eslint-plugin": "^6.4.0",
         "eslint": "^8.0.1",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
@@ -7540,8 +7573,9 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -7555,8 +7589,9 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -8100,8 +8135,9 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -8134,8 +8170,7 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.8.1",
@@ -10432,9 +10467,9 @@
       }
     },
     "node_modules/msw": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.11.tgz",
-      "integrity": "sha512-dAXFS2DxZX0uFqMPhS3oUAu8S/5IQ5qKKSwtXl3/dMTeML0C8JfSvbeWtowYg6pu4Iehgp5L/pHLrlIcG++y/A==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.13.tgz",
+      "integrity": "sha512-FN4GUOTxm+cucXsFFNIZooHWNGGGRZCa5HxcrbdPxSIZMmGkPW2XewidZPcQn6AXO5SisZtfijXFGDlme/BbUw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -10442,7 +10477,7 @@
         "@bundled-es-modules/js-levenshtein": "^2.0.1",
         "@bundled-es-modules/statuses": "^1.0.1",
         "@mswjs/cookies": "^1.1.0",
-        "@mswjs/interceptors": "^0.25.13",
+        "@mswjs/interceptors": "^0.25.14",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
@@ -10471,7 +10506,7 @@
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.7.x <= 5.2.x"
+        "typescript": ">= 4.7.x <= 5.3.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -15167,9 +15202,10 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
   "bin": {
     "toa": "runtime/runtime/bin/toa"
   },
-  "peerDependencies": {
-    "typescript": "^4.9.5"
-  },
   "devDependencies": {
     "@commitlint/cli": "14.1.0",
     "@commitlint/config-conventional": "14.1.0",
@@ -52,6 +49,7 @@
     "msw": "2.0.11",
     "randomstring": "1.3.0",
     "testcontainers": "10.2.2",
+    "typescript": "~5.3.3",
     "ts-jest": "29.1.0",
     "ts-node": "10.9.1"
   },
@@ -75,8 +73,9 @@
     "buildx": "docker buildx create --name toa --use && docker buildx inspect --bootstrap",
     "setup": "docker compose up -d && npm run cluster && npm run buildx && npm run publish:local && npm ci && toa deploy ./integration/context",
     "ci": "rm -rf node_modules && npm exec --workspaces -c \"rm -rf node_modules\" && npm i",
-    "transpile": "npx lerna@7.3.0 run transpile",
-    "retranspile": "npm exec --workspaces -c \"rm -rf transpiled\" && npm run transpile",
+    "clean": "tsc --build --clean",
+    "transpile": "tsc --build",
+    "retranspile": "npm run clean && npm run transpile -- --force",
     "compose": "docker compose rm -f -s -v && docker compose up -d"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -37,21 +37,23 @@
     "@types/jest": "29.5.3",
     "@types/node": "20.8.10",
     "@types/randomstring": "1.1.8",
+    "@typescript-eslint/eslint-plugin": "^6.17.0",
+    "@typescript-eslint/parser": "^6.17.0",
     "clone-deep": "4.0.1",
     "cucumber-tsflow": "4.2.1",
     "dotenv": "16.0.3",
-    "eslint-config-standard-with-typescript": "38.0.0",
+    "eslint-config-standard-with-typescript": "43.0.0",
     "execa": "5.1.1",
     "husky": "8.0.3",
     "jest": "29.5.0",
     "jest-diff": "29.6.2",
     "knex": "2.4.2",
-    "msw": "2.0.11",
+    "msw": "2.0.13",
     "randomstring": "1.3.0",
     "testcontainers": "10.2.2",
-    "typescript": "~5.3.3",
     "ts-jest": "29.1.0",
-    "ts-node": "10.9.1"
+    "ts-node": "10.9.2",
+    "typescript": "~5.3.3"
   },
   "scripts": {
     "prepare": "npx husky install",
@@ -82,9 +84,19 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "coverageProvider": "v8",
-    "coverageReporters": ["lcov", "text", "text-summary", "json"],
-    "coveragePathIgnorePatterns": ["node_modules/", "transpiled/"],
-    "collectCoverageFrom": ["**/source/**"],
+    "coverageReporters": [
+      "lcov",
+      "text",
+      "text-summary",
+      "json"
+    ],
+    "coveragePathIgnorePatterns": [
+      "node_modules/",
+      "transpiled/"
+    ],
+    "collectCoverageFrom": [
+      "**/source/**"
+    ],
     "roots": [
       "<rootDir>/runtime",
       "<rootDir>/connectors",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,41 @@
 {
   "compilerOptions": {
-    "outDir": "/dev/null",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "target": "ESNext",
-    "sourceMap": true,
-    "declaration": true,
-    "esModuleInterop": true,
+    // see https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
+    "lib": [
+      "ES2022"
+    ],
+    "module": "node16",
+    "target": "ES2022",
+    "moduleResolution": "Node16",
+    "resolveJsonModule": true,
     "skipLibCheck": true,
-    "incremental": true,
+    "declaration": true,
+    "declarationMap": true,
     "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": false,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "esModuleInterop": true,
     "experimentalDecorators": true,
     "noImplicitOverride": true,
     "allowJs": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
   },
-  "exclude": [
-    "**/transpiled"
+  "files": [],
+  "references": [
+    {
+      "path": "libraries"
+    },
+    {
+      "path": "extensions"
+    },
+    {
+      "path": "connectors"
+    },
   ]
 }

--- a/typescript.md
+++ b/typescript.md
@@ -10,6 +10,7 @@ To create a new package or migrate an existing one to TypeScript, follow these s
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "./transpiled"
   },
   "include": [
@@ -27,7 +28,6 @@ To create a new package or migrate an existing one to TypeScript, follow these s
 
 ```
   "main": "transpiled/index.js",
-  "types": "transpiled/index.d.ts",
   "scripts": {
     "transpile": "tsc"
   },


### PR DESCRIPTION
This project has pretty cumbersome TypesScript setup with use of `/dev/null` as outDir and lerna for parallel compilation. While all these workarounds are results in some output there are proper documented way to do this better.

This PR converts the TS setup into a [composite project](https://www.typescriptlang.org/docs/handbook/project-references.html) improving the DX and IDE performance for type checking.

In additional, as we are here, we increasing strictness of TS checks and that catches few minor problem (unused arguments and reference to DOM type) and one major problem (`require` of [ESM module](https://github.com/toa-io/toa/pull/474/commits/0eccfa83f6c89926e489036244058d7d5f2a33d4)). Major problem is just silenced as I'm not sure there it's a dead code or should be mitigated in a separated effort.

As part of this PR we also upgrading to TS 5.3 (that requires upgrade of `eslint-config-standard-with-typescript` and `@typescript-eslint/*` packages) and improving ESLint settings related to TS.

This is also moves `typescript` from peerDependencies (where it doesn't belong) to devDependencies.
 