### PR TITLE
chore: remove clone-deep from prod dependencies

### DIFF
--- a/features/steps/.workspace/context.js
+++ b/features/steps/.workspace/context.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const clone = require('clone-deep')
 const { join } = require('node:path')
 
 const { overwrite } = require('@toa.io/generic')
@@ -12,7 +11,7 @@ const { save, load, parse } = require('@toa.io/yaml')
  */
 const template = async (directory, additions) => {
   const path = join(directory, FILENAME)
-  const template = clone(TEMPLATE)
+  const template = structuredClone(TEMPLATE)
 
   if (additions !== undefined) {
     const add = parse(additions)

--- a/libraries/schema/source/schema.js
+++ b/libraries/schema/source/schema.js
@@ -2,7 +2,6 @@
 
 const { default: Ajv } = require('ajv/dist/2019')
 const formats = /** @type {(Ajv) => void} */ require('ajv-formats')
-const clone = require('clone-deep')
 
 const { traverse } = require('@toa.io/generic')
 
@@ -115,7 +114,7 @@ class Schema {
     this.#system = this.#validator.compile(system)
 
     // match
-    const match = clone(schema)
+    const match = structuredClone(schema)
 
     if (match.properties !== undefined) properties(match.properties)
 
@@ -132,7 +131,7 @@ class Schema {
     this.#match = this.#validator.compile(match)
 
     // adapt
-    const adaptive = clone(schema)
+    const adaptive = structuredClone(schema)
 
     if (adaptive.properties !== undefined) properties(adaptive.properties)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16640,8 +16640,10 @@
         "@toa.io/generic": "0.24.0-alpha.18",
         "@toa.io/norm": "0.24.0-alpha.18",
         "@toa.io/schema": "0.24.0-alpha.18",
-        "clone-deep": "4.0.1",
         "dotenv": "16.1.1"
+      },
+      "devDependencies": {
+        "clone-deep": "4.0.1"
       }
     },
     "runtime/boot/node_modules/dotenv": {
@@ -16693,8 +16695,10 @@
         "@toa.io/console": "0.24.0-alpha.18",
         "@toa.io/generic": "0.24.0-alpha.18",
         "@toa.io/yaml": "0.24.0-alpha.18",
-        "clone-deep": "4.0.1",
         "error-value": "0.3.0"
+      },
+      "devDependencies": {
+        "clone-deep": "4.0.1"
       }
     },
     "runtime/core/node_modules/error-value": {

--- a/runtime/boot/package.json
+++ b/runtime/boot/package.json
@@ -25,8 +25,10 @@
     "@toa.io/generic": "0.24.0-alpha.18",
     "@toa.io/norm": "0.24.0-alpha.18",
     "@toa.io/schema": "0.24.0-alpha.18",
-    "clone-deep": "4.0.1",
     "dotenv": "16.1.1"
+  },
+  "devDependencies": {
+    "clone-deep": "4.0.1"
   },
   "gitHead": "61c8e74a336385265767e9fd37d49128cb51b17f"
 }

--- a/runtime/core/package.json
+++ b/runtime/core/package.json
@@ -24,8 +24,10 @@
     "@toa.io/console": "0.24.0-alpha.18",
     "@toa.io/generic": "0.24.0-alpha.18",
     "@toa.io/yaml": "0.24.0-alpha.18",
-    "clone-deep": "4.0.1",
     "error-value": "0.3.0"
+  },
+  "devDependencies": {
+    "clone-deep": "4.0.1"
   },
   "gitHead": "61c8e74a336385265767e9fd37d49128cb51b17f"
 }

--- a/runtime/core/src/contract/request.js
+++ b/runtime/core/src/contract/request.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const clone = require('clone-deep')
-
 const schemas = require('./schemas')
 const { RequestContractException } = require('../exceptions')
 const { Conditions } = require('./conditions')
@@ -30,7 +28,7 @@ class Request extends Conditions {
     }
 
     if (definition.query !== false) {
-      const query = clone(schemas.query)
+      const query = structuredClone(schemas.query)
 
       if (definition.type === 'observation') {
         delete query.properties.version

--- a/runtime/core/src/entities/entity.js
+++ b/runtime/core/src/entities/entity.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const clone = require('clone-deep')
 const { difference, newid } = require('@toa.io/generic')
 
 const { EntityContractException } = require('../exceptions')
@@ -14,7 +13,7 @@ class Entity {
     this.#schema = schema
 
     if (typeof argument === 'object') {
-      const object = clone(argument)
+      const object = structuredClone(argument)
       this.set(object)
       this.#origin = argument
     } else {

--- a/runtime/core/test/entities/entity.test.js
+++ b/runtime/core/test/entities/entity.test.js
@@ -37,7 +37,7 @@ describe('argument', () => {
     const state = fixtures.state()
     const entity = new Entity(fixtures.schema, state)
 
-    expect(entity.get()).toStrictEqual(state)
+    expect(entity.get()).toEqual(state)
   })
 })
 
@@ -51,7 +51,7 @@ it('should provide event', () => {
 
   const event = entity.event()
 
-  expect(event).toStrictEqual({
+  expect(event).toEqual({
     state,
     origin,
     changeset: { foo: 'new value' }


### PR DESCRIPTION
This PR removes redundant production dependency [clone-deep](https://www.npmjs.com/package/clone-deep?activeTab=dependencies) (last release published 5 years ago) in favor of standard [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) function available since Node 17.

`clone-deep` is not only huge dependency for the use case (have 3 subdependencies) but it also doesn't work with `Map` and `Set` objects heavily used in this project and fails on circular references, while standard `structuredClone` handles all those cases with a grace.

We keep `clone-deep` in tests (as it a bigger change), and all unit tests are still passing.