### PR TITLE
feat: add format support to toa export manifest

### DIFF
--- a/runtime/cli/src/commands/export/manifest.js
+++ b/runtime/cli/src/commands/export/manifest.js
@@ -17,6 +17,12 @@ const builder = (yargs) => {
       desc: 'Path to component',
       default: '.'
     })
+    .option('format', {
+      group: 'Command options:',
+      choices: ['yaml', 'json'],
+      desc: 'Exporting format',
+      default: 'yaml'
+    })
 }
 
 exports.command = ['manifest', 'man']

--- a/runtime/cli/src/handlers/export/manifest.js
+++ b/runtime/cli/src/handlers/export/manifest.js
@@ -13,7 +13,10 @@ const print = async (argv) => {
 
   const manifest = await component(path)
 
-  if (argv.error !== true) console.log(dump(manifest))
+  if (argv.error !== true) {
+    const result = argv.format === 'json' ? JSON.stringify(manifest, null, 2) : dump(manifest)
+    console.log(result)
+  }
 }
 
 exports.manifest = print


### PR DESCRIPTION
Adding `--format` option to `toa export manifest`:

```sh
$ toa export manifest --help                                             
toa export manifest

Print manifest

Command options:
  -e, --error   Print errors only                                      [boolean]
  -p, --path    Path to component                        [string] [default: "."]
      --format  Exporting format     [choices: "yaml", "json"] [default: "yaml"]

Options:
      --log      Log level
      --env      Path to environment variables file (.env format)       [string]
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]
```