### PR TITLE
fix: dereference schema at toa export manifest

### DIFF
--- a/runtime/cli/src/handlers/export/manifest.js
+++ b/runtime/cli/src/handlers/export/manifest.js
@@ -3,6 +3,7 @@
 const { component } = require('@toa.io/norm')
 const { console } = require('@toa.io/console')
 const yaml = require('@toa.io/yaml')
+const { definitions: loadDefinitions } = require('@toa.io/schema/source/definitions')
 
 const { components: find } = require('../../util/find')
 
@@ -14,10 +15,17 @@ const print = async (argv) => {
   const manifest = await component(path)
 
   if (argv.error !== true) {
+    // FIXME: workaround for unresolvable definitions references in the schema
+    const defs = []
+    loadDefinitions({
+      addSchema: defs.push.bind(defs),
+    })
+    const { definitions, $id } = defs[0]
+    const dereferenced = JSON.parse(JSON.stringify(manifest).replaceAll($id, ''))
+    dereferenced.entity.schema.definitions = definitions
     const result = argv.output === 'json'
-      ? JSON.stringify(manifest, null, 2)
-      : yaml.dump(manifest)
-
+      ? JSON.stringify(dereferenced, null, 2)
+      : yaml.dump(dereferenced)
     console.log(result)
   }
 }


### PR DESCRIPTION
Adding a workaround to remove unresolvable schema reference in `toa export manifest`.
We cannot just remove reference in the original prototype schema as it covered by test and so, to reduce blast radius we adding dereference logic in the `toa export manifest` command.

After this fix output of `toa export manifest --path components/identity.basic --format=json | jq .entity.schema` will be:

```json        
{
  "properties": {
    "username": {
      "type": "string",
      "definitions": {}
    },
    "password": {
      "type": "string",
      "definitions": {}
    },
    "id": {
      "$ref": "#/definitions/id",
      "definitions": {}
    },
    "_version": {
      "type": "integer",
      "definitions": {}
    }
  },
  "type": "object",
  "additionalProperties": false,
  "required": [
    "username",
    "password",
    "id"
  ],
  "definitions": {
    "schema": {
      "$ref": "https://json-schema.org/draft/2019-09/schema"
    },
    "token": {
      "type": "string",
      "pattern": "^[a-zA-Z]([a-zA-Z0-9]{1,31})?$"
    },
    "id": {
      "type": "string",
      "pattern": "^[a-fA-F0-9]{32}$"
    },
    "name": {
      "type": "string",
      "pattern": "^[a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?$"
    },
    "label": {
      "type": "string",
      "pattern": "^([a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?)(-([a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?))*$"
    },
    "endpoint": {
      "type": "string",
      "pattern": "^([a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?)(\\.([a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?)){2}$"
    },
    "locator": {
      "type": "string",
      "pattern": "^([a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?)(\\.([a-zA-Z]+([_a-zA-Z0-9]*[a-zA-Z0-9]+)?))$"
    },
    "version": {
      "type": "string",
      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
    }
  }
}
```