### PR TITLE
fix(http): prepend capturing expression with a whitespace

### DIFF
--- a/libraries/http/source/Captures.test.ts
+++ b/libraries/http/source/Captures.test.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-template-curly-in-string */
+
+import { Captures } from './Captures'
+
+let captures: Captures
+
+beforeEach(() => {
+  captures = new Captures()
+})
+
+it('should capture parts values', async () => {
+  captures.capture('hello world', 'hello ${{ word }}')
+
+  const word = captures.get('word')
+
+  expect(word).toBe('world')
+})
+
+it('should not capture parts of the words', async () => {
+  captures.capture('super-hello world', 'hello ${{ word }}')
+
+  const word = captures.get('word')
+
+  expect(word).toBe(undefined)
+})

--- a/libraries/http/source/Captures.ts
+++ b/libraries/http/source/Captures.ts
@@ -24,10 +24,10 @@ export class Captures extends Map<string, string> {
 
   /**
    * @returns `undefined` if `source` doesn't match `matcher`
-   * or array of captured keys (may be empty)
+   * or array of captured keys (can be empty)
    */
   public capture (source: string, matcher: string): readonly string[] | undefined {
-    const expression = regexpEscape(matcher).replaceAll(CAPTURE,
+    const expression = PADDING + regexpEscape(matcher).replaceAll(CAPTURE,
       (_, name: string) => `(?<${Buffer.from(name).toString('base64url')}>\\S{1,2048})`)
 
     const rx = new RegExp(expression, 'i')
@@ -55,3 +55,4 @@ function regexpUnescape (text: string): string {
 
 const CAPTURE = /\\\$\\{\\{\s*(?<name>\S{0,32})\s*\\}\\}/g
 const SUBSTITUTE = /\${{\s*(?<name>\S{0,32})\s*}}/g
+const PADDING = '(?:^|\\s+)'


### PR DESCRIPTION
Fixes the problem when the following matcher:

```
id: ${{ id }}
```

matches the:

```
x-whatever-id: value
```