### PR TITLE
fix: restoring storage secrets

### DIFF
--- a/extensions/storages/source/Factory.ts
+++ b/extensions/storages/source/Factory.ts
@@ -23,12 +23,12 @@ export class Factory {
     return new Aspect(storages)
   }
 
-  public createStorage ({ provider: providerId, ...props }: any): Storage {
+  public createStorage (componentName: string, { provider: providerId, ...props }: any): Storage {
     validateProviderId(providerId)
 
     const Provider = providers[providerId]
 
-    const secrets = this.resolveSecrets(providerId, Provider)
+    const secrets = this.resolveSecrets(componentName, Provider)
 
     const provider = new Provider({ ...props, secrets })
 
@@ -38,20 +38,20 @@ export class Factory {
   private createStorages (): Storages {
     const storages: Storages = {}
 
-    for (const [name, props] of Object.entries(this.declaration))
-      storages[name] = this.createStorage(props)
+    for (const [componentName, props] of Object.entries(this.declaration))
+      storages[componentName] = this.createStorage(componentName, props)
 
     return storages
   }
 
-  private resolveSecrets (name: string,
+  private resolveSecrets (componentName: string,
     Class: ProviderConstructor): Record<string, string | undefined> {
     if (Class.SECRETS === undefined) return {}
 
     const secrets: Record<string, string | undefined> = {}
 
     for (const secret of Class.SECRETS) {
-      const variable = `${SERIALIZATION_PREFIX}_${name.toUpperCase()}_${secret.name.toUpperCase()}`
+      const variable = `${SERIALIZATION_PREFIX}_${componentName}_${secret.name}`.toUpperCase()
       const value = process.env[variable]
 
       assert.ok(secret.optional === true || value !== undefined,

--- a/extensions/storages/source/deployment.ts
+++ b/extensions/storages/source/deployment.ts
@@ -44,14 +44,14 @@ export function validateProviderId (id: string | undefined): asserts id is keyof
 function getSecrets (annotation: ValidatedAnnotation): Variable[] {
   const secrets: Variable[] = []
 
-  for (const [storage, props] of Object.entries(annotation)) {
+  for (const [componentName, props] of Object.entries(annotation)) {
     const Provider = providers[props.provider]
 
     for (const secret of Provider.SECRETS)
       secrets.push({
-        name: `${SERIALIZATION_PREFIX}_${storage.toUpperCase()}_${secret.name.toUpperCase()}`,
+        name: `${SERIALIZATION_PREFIX}_${componentName}_${secret.name}`.toUpperCase(),
         secret: {
-          name: `toa-storages-${storage}`,
+          name: `toa-storages-${componentName}`,
           key: secret.name,
           optional: secret.optional
         }


### PR DESCRIPTION
We were passing provider id (`s3`) instead of component name to restoring secrets and so they were always empty.

The test will be updated separately as we already had the test covering this functionality but it seems like LocalStack were not enforcing this. Will properly investigate and make a dedicated PR with a regression test / mock changes.