### PR TITLE
fix(exposition): fix root annotation processing

### DIFF
--- a/extensions/exposition/features/steps/Gateway.ts
+++ b/extensions/exposition/features/steps/Gateway.ts
@@ -18,8 +18,7 @@ export class Gateway {
     const annotation = parse(yaml)
 
     if ('/' in annotation) {
-      const node = { '/': annotation['/'] }
-      const tree = syntax.parse(node, shortcuts)
+      const tree = syntax.parse(annotation['/'], shortcuts)
 
       process.env.TOA_EXPOSITION = encode(tree)
     }

--- a/extensions/exposition/features/vary.feature
+++ b/extensions/exposition/features/vary.feature
@@ -46,7 +46,7 @@ Feature: The Vary directive family
           GET:
             anonymous: true
             vary:embed:
-              name: language  # embed resolved language code as a `name` property of the operation input
+              name: language
             endpoint: compute
       """
     When the following request is received:
@@ -60,9 +60,6 @@ Feature: The Vary directive family
       200 OK
       content-type: application/yaml
       content-language: fr
-      vary: accept-language, accept
-
-      Hello fr
       """
 
 

--- a/extensions/exposition/features/vary.feature
+++ b/extensions/exposition/features/vary.feature
@@ -1,6 +1,6 @@
 Feature: The Vary directive family
 
-  Scenario Outline: Embedding a language code
+  Scenario Outline: Embedding a `<result>` language code
     Given the `echo` is running with the following manifest:
       """yaml
       exposition:
@@ -32,6 +32,39 @@ Feature: The Vary directive family
       | en_US  | en     |
       | fr     | fr     |
       | sw     | en     |
+
+  Scenario: Listing languages on the root
+    Given the annotation:
+    """
+    /:
+      vary:languages: [en, fr]
+    """
+    And the `echo` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          GET:
+            anonymous: true
+            vary:embed:
+              name: language  # embed resolved language code as a `name` property of the operation input
+            endpoint: compute
+      """
+    When the following request is received:
+      """
+      GET /echo/ HTTP/1.1
+      accept: application/yaml
+      accept-language: fr
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      content-type: application/yaml
+      content-language: fr
+      vary: accept-language, accept
+
+      Hello fr
+      """
+
 
   Scenario: Embedding a value of an arbitrary header
     Given the `echo` is running with the following manifest:

--- a/extensions/exposition/source/RTD/Tree.ts
+++ b/extensions/exposition/source/RTD/Tree.ts
@@ -25,6 +25,9 @@ export class Tree<
   }
 
   public match (path: string): Match<TEndpoint, TDirectives> | null {
+    if (path === '/')
+      return { node: this.trunk, parameters: [] }
+
     const fragments = fragment(path)
 
     return this.trunk.match(fragments)

--- a/extensions/exposition/source/deployment.ts
+++ b/extensions/exposition/source/deployment.ts
@@ -27,8 +27,7 @@ export function deployment (_: unknown, annotation: Annotation | undefined): Dep
     }
 
   if (annotation?.['/'] !== undefined) {
-    const node = { '/': annotation['/'] }
-    const tree = parse(node, shortcuts)
+    const tree = parse(annotation['/'], shortcuts)
 
     service.variables.push({
       name: 'TOA_EXPOSITION',


### PR DESCRIPTION
Will fix directives attachment to the resource tree root.

```yaml
# context.toa.yaml

exposition:
  /:
    vary:languages: [en, fr]
```