### PR TITLE
fix(exposition): resolve routing conflicts

### DIFF
--- a/extensions/exposition/features/routes.feature
+++ b/extensions/exposition/features/routes.feature
@@ -87,3 +87,40 @@ Feature: Routes
 
       Hello
       """
+
+  Scenario: Routes with naming conflicts
+    Given the Gateway is running
+    And the `users` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          POST: create
+      """
+    And the `users.properties` is running with the following manifest:
+      """yaml
+      exposition:
+        /:id:
+          GET: observe
+      """
+    When the following request is received:
+      """
+      GET /users/properties/b5534021e30042259badffbd1831e472/ HTTP/1.1
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+
+      newbie: false
+      """
+    When the following request is received:
+      """
+      POST /users/ HTTP/1.1
+      content-type: application/yaml
+
+      name: Alice
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+      """

--- a/extensions/exposition/features/steps/components/users.properties/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/users.properties/manifest.toa.yaml
@@ -1,0 +1,13 @@
+namespace: users
+name: properties
+
+entity:
+  schema:
+    newbie: false
+  dependent: true
+
+operations:
+  transit:
+    concurrency: retry
+    input:
+      newbie*: .

--- a/extensions/exposition/features/steps/components/users/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/users/manifest.toa.yaml
@@ -9,3 +9,6 @@ operations:
     concurrency: retry
     input:
       name*: ~
+  create:
+    query: false
+    forward: transit

--- a/extensions/exposition/source/directives/cors/CORS.ts
+++ b/extensions/exposition/source/directives/cors/CORS.ts
@@ -1,8 +1,7 @@
 import type { Input, Output } from '../../io'
-import type { Family } from '../../Directive'
 import type { Interceptor } from '../../Interception'
 
-export class CORS implements Family, Interceptor {
+export class CORS implements Interceptor {
   public readonly name = 'cors'
   public readonly mandatory = true
 
@@ -16,10 +15,6 @@ export class CORS implements Family, Interceptor {
     'cache-control': 'public, max-age=3600',
     vary: 'origin'
   })
-
-  public create (): null {
-    return null
-  }
 
   public intercept (input: Input): Output {
     const origin = input.headers.origin

--- a/extensions/exposition/source/directives/index.ts
+++ b/extensions/exposition/source/directives/index.ts
@@ -7,5 +7,5 @@ import { vary } from './vary'
 import type { Family } from '../Directive'
 import type { Interceptor } from '../Interception'
 
-export const families: Family[] = [authorization, cache, octets, cors, vary, dev]
+export const families: Family[] = [authorization, cache, octets, vary, dev]
 export const interceptors: Interceptor[] = [cors]

--- a/extensions/exposition/source/manifest.test.ts
+++ b/extensions/exposition/source/manifest.test.ts
@@ -21,16 +21,8 @@ it('should create branch', async () => {
   const node = manifest(declaration, mf)
 
   expect(node).toBeDefined()
-
-  // namespace route
   expect(node.routes).toHaveLength(1)
-  expect(node.routes[0].path).toBe('/' + namespace)
-
-  const ns = node.routes[0].node
-
-  // component route
-  expect(ns.routes).toHaveLength(1)
-  expect(ns.routes[0].path).toBe('/' + name)
+  expect(node.routes[0].path).toBe('/' + namespace + '/' + name)
 })
 
 it('should not create node for default namespace', async () => {
@@ -49,10 +41,9 @@ it('should throw on invalid declaration type', async () => {
 it('should set namespace and component', async () => {
   const node = manifest(declaration, mf)
 
-  const ns = node.routes[0].node
-  const cm = ns.routes[0].node
-  const root = cm.routes[0].node
-  const GET = root.methods[0]
+  const root = node.routes[0].node
+  const intemediate = root.routes[0].node
+  const GET = intemediate.methods[0]
 
   expect(GET.mapping?.namespace).toBe(namespace)
   expect(GET.mapping?.component).toBe(name)

--- a/extensions/exposition/source/manifest.test.ts
+++ b/extensions/exposition/source/manifest.test.ts
@@ -35,7 +35,7 @@ it('should not create node for default namespace', async () => {
 })
 
 it('should throw on invalid declaration type', async () => {
-  expect(() => manifest('hello' as unknown as object, mf)).toThrow('RTD parse error')
+  expect(() => manifest('hello' as unknown as object, mf)).toThrow('Exposition declaration must be an object')
 })
 
 it('should set namespace and component', async () => {

--- a/extensions/exposition/source/manifest.ts
+++ b/extensions/exposition/source/manifest.ts
@@ -4,22 +4,21 @@ import * as schemas from './schemas'
 import type { Manifest } from '@toa.io/norm'
 
 export function manifest (declaration: object, manifest: Manifest): Node {
-  declaration = wrap(manifest.name, declaration)
-
-  if (manifest.namespace !== undefined && manifest.namespace !== 'default')
-    declaration = wrap(manifest.namespace, declaration)
+  declaration = wrap(declaration, manifest.namespace, manifest.name)
 
   const node = parse(declaration, shortcuts)
 
   concretize(node, manifest)
-
   schemas.node.validate(node)
 
   return node
 }
 
-function wrap (segment: string, declaration: object): object {
-  return { ['/' + segment]: { protected: true, ...declaration } }
+function wrap (declaration: object, namespace: string, name: string): object {
+  const path = (namespace === undefined || namespace === 'default' ? '' : '/' + namespace) +
+    '/' + name
+
+  return { [path]: { protected: true, ...declaration } }
 }
 
 function concretize (node: Node, manifest: Manifest): void {

--- a/extensions/exposition/source/manifest.ts
+++ b/extensions/exposition/source/manifest.ts
@@ -1,9 +1,13 @@
+import assert from 'node:assert'
 import { parse, type Node, type Method, type Query } from './RTD/syntax'
 import { shortcuts } from './Directive'
 import * as schemas from './schemas'
 import type { Manifest } from '@toa.io/norm'
 
 export function manifest (declaration: object, manifest: Manifest): Node {
+  assert.ok(typeof declaration === 'object' && declaration !== null,
+    'Exposition declaration must be an object')
+
   declaration = wrap(declaration, manifest.namespace, manifest.name)
 
   const node = parse(declaration, shortcuts)


### PR DESCRIPTION
# Before

Component `a.b` created resource tree nodes:

```yaml
/a:
  /b:
    ...
```

and component `default.a` created nodes:

```yaml
/a:
 ...
```

This led to overwriting (replacing) nodes on the tree. Route `/a/b` became unavailable.

# After

`a.b.` creates:

```yaml
/a/b:
   ...
```

`default.a` creates:

```yaml
/a:
   ...
```

Basically, this is the reason why @maxacoustic observed `405 Method Not Allowed` responses, as the node with required method was replaced by another node.