### PR TITLE
feat(exposition): add route parameters to the workflow input

### DIFF
--- a/extensions/exposition/documentation/octets.md
+++ b/extensions/exposition/documentation/octets.md
@@ -218,6 +218,7 @@ The following input will be passed to each endpoint:
 storage: string
 path: string
 entry: Entry
+parameters: Record<string, string> # route parameters
 ```
 
 See [Entry](/extensions/storages/readme.md#entry) and an

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -213,3 +213,36 @@ Feature: Octets storage workflows
       """
       200 OK
       """
+
+  Scenario: Passing parameters to the workflow
+    Given the `octets.tester` is running
+    And the annotation:
+      """yaml
+      /:
+        /:a/:b:
+          auth:anonymous: true
+          octets:context: octets
+          POST:
+            octets:store:
+              workflow:
+                concat: octets.tester.concat
+      """
+    When the stream of `lenna.ascii` is received with the following headers:
+      """
+      POST /hello/world/ HTTP/1.1
+      accept: application/yaml
+      content-type: application/octet-stream
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+      content-type: multipart/yaml; boundary=cut
+
+      --cut
+      id: 10cf16b458f759e0d617f2f3d83599ff
+      type: application/octet-stream
+      size: 8169
+      --cut
+      concat: hello world
+      --cut--
+      """

--- a/extensions/exposition/features/steps/components/octets.tester/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/octets.tester/manifest.toa.yaml
@@ -9,8 +9,10 @@ operations:
       storage*: string
       path*: string
       entry: object
+      parameters: object
   bar: *operation
   baz: *operation
   err: *operation
   echo: *operation
+  concat: *operation
   diversify: *operation

--- a/extensions/exposition/features/steps/components/octets.tester/operations/concat.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/concat.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function concat (input) {
+  return input.parameters.a + ' ' + input.parameters.b
+}
+
+exports.computation = concat

--- a/extensions/exposition/features/steps/components/octets.tester/operations/echo.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/echo.js
@@ -1,7 +1,7 @@
 'use strict'
 
-async function baz (input) {
+function echo (input) {
   return input.entry.id
 }
 
-exports.computation = baz
+exports.computation = echo

--- a/extensions/exposition/source/directives/octets/Octets.ts
+++ b/extensions/exposition/source/directives/octets/Octets.ts
@@ -10,6 +10,7 @@ import type { Component } from '@toa.io/core'
 import type { Remotes } from '../../Remotes'
 import type { Family } from '../../Directive'
 import type { Directive, Input } from './types'
+import type { Parameter } from '../../RTD'
 
 export class Octets implements Family<Directive> {
   public readonly name: string = 'octets'
@@ -28,7 +29,8 @@ export class Octets implements Family<Directive> {
     return new Class(value, this.discovery, remotes)
   }
 
-  public async preflight (directives: Directive[], input: Input): Promise<Output> {
+  public async preflight
+  (directives: Directive[], input: Input, parameters: Parameter[]): Promise<Output> {
     let context: Context | null = null
     let action: Directive | null = null
 
@@ -51,7 +53,7 @@ export class Octets implements Family<Directive> {
     if (targeted !== action.targeted)
       throw new NotFound(`Trailing slash is ${action.targeted ? 'redundant' : 'required'}.`)
 
-    return await action.apply(context.storage, input)
+    return await action.apply(context.storage, input, parameters)
   }
 }
 

--- a/extensions/exposition/source/directives/octets/Store.ts
+++ b/extensions/exposition/source/directives/octets/Store.ts
@@ -3,6 +3,7 @@ import { BadRequest, UnsupportedMediaType } from '../../HTTP'
 import { cors } from '../cors'
 import * as schemas from './schemas'
 import { Workflow } from './workflow'
+import type { Parameter } from '../../RTD'
 import type { Unit } from './workflow'
 import type { Entry } from '@toa.io/extensions.storages'
 import type { Remotes } from '../../Remotes'
@@ -36,7 +37,7 @@ export class Store implements Directive {
     cors.allowHeader('content-meta')
   }
 
-  public async apply (storage: string, request: Input): Promise<Output> {
+  public async apply (storage: string, request: Input, parameters: Parameter[]): Promise<Output> {
     this.storage ??= await this.discovery.storage
 
     const input: StoreInput = { storage, request }
@@ -52,13 +53,14 @@ export class Store implements Directive {
 
     return match<Output>(entry,
       Error, (error: ErrorType) => this.throw(error),
-      () => this.reply(request, storage, entry))
+      () => this.reply(request, storage, entry, parameters))
   }
 
-  private reply (request: Input, storage: string, entry: Entry): Output {
+  // eslint-disable-next-line max-params
+  private reply (request: Input, storage: string, entry: Entry, parameters: Parameter[]): Output {
     const body = this.workflow === undefined
       ? entry
-      : this.workflow.execute(request, storage, entry)
+      : this.workflow.execute(request, storage, entry, parameters)
 
     return { body }
   }

--- a/extensions/exposition/source/directives/octets/types.ts
+++ b/extensions/exposition/source/directives/octets/types.ts
@@ -1,9 +1,10 @@
+import type { Parameter } from '../../RTD'
 import type * as io from '../../io'
 
 export interface Directive {
   readonly targeted: boolean
 
-  apply: (storage: string, input: Input) => io.Output | Promise<io.Output>
+  apply: (storage: string, input: Input, parameters: Parameter[]) => io.Output | Promise<io.Output>
 }
 
 export interface Extension {

--- a/extensions/exposition/source/directives/octets/workflow/Execution.ts
+++ b/extensions/exposition/source/directives/octets/workflow/Execution.ts
@@ -41,7 +41,7 @@ export class Execution extends Readable {
 
   private async execute (unit: Unit): Promise<void> {
     const promises = Object.entries(unit).map(async ([step, endpoint]) => {
-      const result = await this.call(endpoint)
+      const result = await this.call(endpoint).catch((error: Error) => console.error(error))
 
       if (result instanceof Error) {
         this.push({ error: { step, ...result } })

--- a/extensions/exposition/source/directives/octets/workflow/Execution.ts
+++ b/extensions/exposition/source/directives/octets/workflow/Execution.ts
@@ -74,4 +74,5 @@ export interface Context {
   storage: string
   path: string
   entry: Entry
+  parameters: Record<string, string>
 }

--- a/extensions/exposition/source/directives/octets/workflow/Workflow.ts
+++ b/extensions/exposition/source/directives/octets/workflow/Workflow.ts
@@ -1,6 +1,8 @@
 import { posix } from 'node:path'
 import { match } from 'matchacho'
 import { Execution } from './Execution'
+import type { Context } from './Execution'
+import type { Parameter } from '../../../RTD'
 import type { Input } from '../types'
 import type { Entry } from '@toa.io/extensions.storages'
 import type { Remotes } from '../../../Remotes'
@@ -17,9 +19,16 @@ export class Workflow {
     this.remotes = remotes
   }
 
-  public execute (request: Input, storage: string, entry: Entry): Execution {
+  // eslint-disable-next-line max-params
+  public execute
+  (request: Input, storage: string, entry: Entry, params: Parameter[]): Execution {
     const path = posix.join(request.path, entry.id)
-    const context = { storage, path, entry }
+    const parameters: Record<string, string> = {}
+
+    for (const { name, value } of params)
+      parameters[name] = value
+
+    const context: Context = { storage, path, entry, parameters }
 
     return new Execution(context, this.units, this.remotes)
   }


### PR DESCRIPTION
Workflow attached to `/users/:id` will send `parameters: { id: x }` to operation calls.