### PR TITLE
feat(identity-federation): support symmetric OpenID tokens

### DIFF
--- a/extensions/exposition/components/identity.federation/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.federation/manifest.toa.yaml
@@ -60,9 +60,18 @@ configuration:
                 type: string
               uniqueItems: true
               minItems: 1
-            secret:
-              description: HS256 secret
-              type: string
+            secrets:
+              description: Symmetric encryption secrets
+              type: object
+              patternProperties:
+                ^HS\d{3}$:
+                  type: object
+                  patternProperties:
+                    ^\w+$:
+                      type: string
+                  minProperties: 1
+              additionalProperties: false
+              minProperties: 1
           required:
             - issuer
       explicit_identity_creation:

--- a/extensions/exposition/components/identity.federation/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.federation/manifest.toa.yaml
@@ -60,6 +60,9 @@ configuration:
                 type: string
               uniqueItems: true
               minItems: 1
+            secret:
+              description: HS256 secret
+              type: string
           required:
             - issuer
       explicit_identity_creation:

--- a/extensions/exposition/components/identity.federation/source/authenticate.ts
+++ b/extensions/exposition/components/identity.federation/source/authenticate.ts
@@ -1,9 +1,9 @@
 import { type Maybe } from '@toa.io/types'
 import { Err } from 'error-value'
-import { assertionsAsValues } from './assertions-as-values.cjs'
+import { assertionsAsValues } from './lib/assertions-as-values.js'
 import {
   validateIdToken
-} from './jwt.cjs'
+} from './lib/jwt'
 import type { Request } from '@toa.io/core'
 import type { AuthenticateOutput, Context } from './types'
 

--- a/extensions/exposition/components/identity.federation/source/create.ts
+++ b/extensions/exposition/components/identity.federation/source/create.ts
@@ -1,5 +1,5 @@
-import { assertionsAsValues } from './assertions-as-values.cjs'
-import { validateIdToken } from './jwt.cjs'
+import { assertionsAsValues } from './lib/assertions-as-values.js'
+import { validateIdToken } from './lib/jwt'
 import type { Request } from '@toa.io/core'
 import type { Context, Entity } from './types'
 

--- a/extensions/exposition/components/identity.federation/source/lib/assertions-as-values.ts
+++ b/extensions/exposition/components/identity.federation/source/lib/assertions-as-values.ts
@@ -4,8 +4,7 @@ import * as assert from 'node:assert'
  * Wrapping function that returns assertion errors as function return value
  */
 export function assertionsAsValues<T extends (...args: any[]) => Promise<any>> (
-  fn: T
-) {
+  fn: T) {
   return async (...args: Parameters<T>): Promise<ReturnType<T> | Error> => {
     try {
       return await fn(...args)

--- a/extensions/exposition/components/identity.federation/source/lib/jwt.test.ts
+++ b/extensions/exposition/components/identity.federation/source/lib/jwt.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
-import { SupportedTokenAlg } from '../types'
 import { validateSignature, decodeJwt } from './jwt'
 
 describe('jwt', () => {
@@ -16,15 +15,20 @@ describe('jwt', () => {
     // https://pyjwt.readthedocs.io/en/latest/usage.html#encoding-decoding-tokens-with-hs256
 
     await expect(validateSignature({
-      header: { alg: SupportedTokenAlg.HS256 },
-      payload: { iss: 'test-issuer' },
+      header: { alg: 'HS256', kid: 'k2' },
+      payload: { iss: 'test-issuer', aud: 'test', sub: '0', exp: 0, iat: 0 },
       rawHeader: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
       rawPayload: 'eyJzb21lIjoicGF5bG9hZCJ9',
       signature: '4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg',
       trusted: [
         {
           issuer: 'test-issuer',
-          secret: 'secret'
+          secrets: {
+            HS256: {
+              k1: 'old-secret',
+              k2: 'secret'
+            }
+          }
         }
       ]
     } as Parameters<typeof validateSignature>[0])).resolves.toBeUndefined()
@@ -32,15 +36,19 @@ describe('jwt', () => {
 
   test('symmetric fail', async () => {
     await expect(validateSignature({
-      header: { alg: SupportedTokenAlg.HS256 },
-      payload: { iss: 'test-issuer' },
+      header: { alg: 'HS256' },
+      payload: { iss: 'test-issuer', aud: 'test', sub: '0', exp: 0, iat: 0 },
       rawHeader: 'header',
       rawPayload: 'payload',
       signature: 'signature',
       trusted: [
         {
           issuer: 'test-issuer',
-          secret: 'secret'
+          secrets: {
+            HS256: {
+              theKey: 'secret'
+            }
+          }
         }
       ]
     } as Parameters<typeof validateSignature>[0])).rejects.toThrow('Signature does not match')

--- a/extensions/exposition/components/identity.federation/source/lib/jwt.test.ts
+++ b/extensions/exposition/components/identity.federation/source/lib/jwt.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable max-len */
+/* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { SupportedTokenAlg } from '../types'
+import { validateSignature, decodeJwt } from './jwt'
+
+describe('jwt', () => {
+  test('decode', () => {
+    const { header, payload } = decodeJwt('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzb21lIjoicGF5bG9hZCJ9.4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg')
+
+    expect(header).toMatchObject({ alg: 'HS256' })
+    expect(payload).toEqual({ some: 'payload' })
+  })
+
+  test('symmetric pass', async () => {
+    // example from
+    // https://pyjwt.readthedocs.io/en/latest/usage.html#encoding-decoding-tokens-with-hs256
+
+    await expect(validateSignature({
+      header: { alg: SupportedTokenAlg.HS256 },
+      payload: { iss: 'test-issuer' },
+      rawHeader: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      rawPayload: 'eyJzb21lIjoicGF5bG9hZCJ9',
+      signature: '4twFt5NiznN84AWoo1d7KO1T_yoc0Z6XOpOVswacPZg',
+      trusted: [
+        {
+          issuer: 'test-issuer',
+          secret: 'secret'
+        }
+      ]
+    } as Parameters<typeof validateSignature>[0])).resolves.toBeUndefined()
+  })
+
+  test('symmetric fail', async () => {
+    await expect(validateSignature({
+      header: { alg: SupportedTokenAlg.HS256 },
+      payload: { iss: 'test-issuer' },
+      rawHeader: 'header',
+      rawPayload: 'payload',
+      signature: 'signature',
+      trusted: [
+        {
+          issuer: 'test-issuer',
+          secret: 'secret'
+        }
+      ]
+    } as Parameters<typeof validateSignature>[0])).rejects.toThrow('Signature does not match')
+  })
+})

--- a/extensions/exposition/components/identity.federation/source/schemas.ts
+++ b/extensions/exposition/components/identity.federation/source/schemas.ts
@@ -43,7 +43,19 @@ export interface TrustConfiguration {
    */
   audience?: [string, ...string[]];
   /**
-   * HS256 secret
+   * Symmetric encryption secrets
    */
-  secret?: string;
+  secrets?: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^HS\d{3}$".
+     */
+    [k: string]: {
+      /**
+       * This interface was referenced by `undefined`'s JSON-Schema definition
+       * via the `patternProperty` "^\w+$".
+       */
+      [k: string]: string;
+    };
+  };
 }

--- a/extensions/exposition/components/identity.federation/source/schemas.ts
+++ b/extensions/exposition/components/identity.federation/source/schemas.ts
@@ -42,4 +42,8 @@ export interface TrustConfiguration {
    * @minItems 1
    */
   audience?: [string, ...string[]];
+  /**
+   * HS256 secret
+   */
+  secret?: string;
 }

--- a/extensions/exposition/components/identity.federation/source/types.ts
+++ b/extensions/exposition/components/identity.federation/source/types.ts
@@ -31,9 +31,14 @@ interface IdentityTokensRevokeInput {
   query: Query
 }
 
+export enum SupportedTokenAlg {
+  RS256 = 'RS256',
+  HS256 = 'HS256'
+}
+
 export interface JwtHeader {
   typ: string
-  alg: string
+  alg: SupportedTokenAlg
   kid?: string
 }
 

--- a/extensions/exposition/components/identity.federation/source/types.ts
+++ b/extensions/exposition/components/identity.federation/source/types.ts
@@ -31,14 +31,9 @@ interface IdentityTokensRevokeInput {
   query: Query
 }
 
-export enum SupportedTokenAlg {
-  RS256 = 'RS256',
-  HS256 = 'HS256'
-}
-
 export interface JwtHeader {
-  typ: string
-  alg: SupportedTokenAlg
+  typ?: string
+  alg: string
   kid?: string
 }
 

--- a/extensions/exposition/documentation/components.md
+++ b/extensions/exposition/documentation/components.md
@@ -100,7 +100,7 @@ The configuration schema alongside default values is described in the [component
 
 No federated tokens are accepted by default until at least one entry is added to the `trust` configuration.
 
-Toa supports either asymmetric RS256 or symmetric HS256 tokens with pre-shared secrets.
+Toa supports either asymmetric RS256 or symmetric HS256 / HS384 / HS512 tokens with pre-shared secrets.
 
 ```yaml
 # context.toa.yaml
@@ -114,7 +114,9 @@ configuration:
           - https://github.com/temich
 
       - issuer: some.private.issuer
-        secret: <secret-to-be-used-for-hs256>
+        secrets:
+          HS256:
+            k1: <secret-to-be-used-for-hs256>
 ```
 
 ## Stateless tokens

--- a/extensions/exposition/documentation/components.md
+++ b/extensions/exposition/documentation/components.md
@@ -100,6 +100,8 @@ The configuration schema alongside default values is described in the [component
 
 No federated tokens are accepted by default until at least one entry is added to the `trust` configuration.
 
+Toa supports either asymmetric RS256 or symmetric HS256 tokens with pre-shared secrets.
+
 ```yaml
 # context.toa.yaml
 
@@ -110,6 +112,9 @@ configuration:
         audience:
           - https://github.com/tinovyatkin
           - https://github.com/temich
+
+      - issuer: some.private.issuer
+        secret: <secret-to-be-used-for-hs256>
 ```
 
 ## Stateless tokens

--- a/extensions/exposition/documentation/identity.md
+++ b/extensions/exposition/documentation/identity.md
@@ -84,7 +84,10 @@ configuration:
       - issuer: https://appleid.apple.com
 
       - issuer: private.entity
-        secret: <THE-SECRET-STRING-FOR-HS256>
+        secrets:
+          HS384:
+            key0: <THE-SECRET-STRING-FOR-HS384>
+            key1: <THE-SECRET-STRING-FOR-HS384> # selected by `kid` in the JWT header
 ```
 
 ## Identity inception

--- a/extensions/exposition/documentation/identity.md
+++ b/extensions/exposition/documentation/identity.md
@@ -80,7 +80,11 @@ configuration:
       - issuer: https://accounts.google.com
         audience:
           - <GOOGLE_CLIENT_ID>
+
       - issuer: https://appleid.apple.com
+
+      - issuer: private.entity
+        secret: <THE-SECRET-STRING-FOR-HS256>
 ```
 
 ## Identity inception

--- a/extensions/exposition/features/identity.federation.feature
+++ b/extensions/exposition/features/identity.federation.feature
@@ -54,6 +54,34 @@ Feature: Identity Federation
       id: ${{ User.id }}
       """
 
+  Scenario: Getting identity for a user with symmetric tokens
+    Given the `identity.federation` configuration:
+      """yaml
+      explicit_identity_creation: false
+      trust:
+        - issuer: http://localhost:44444
+          secret: the-secret
+      """
+    And the IDP symmetric token for GoodUser is issued with following secret:
+      """
+      the-secret
+      """
+    When the following request is received:
+      """
+      GET /identity/ HTTP/1.1
+      authorization: Bearer ${{ GoodUser.id_token }}
+      accept: application/yaml
+      content-type: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      authorization: Token ${{ GoodUser.token }}
+
+      id: ${{ GoodUser.id }}
+      scheme: bearer
+      """
+
   Scenario: Creating an Identity using inception with existing credentials
     Given the `identity.federation` configuration:
       """yaml

--- a/extensions/exposition/features/identity.federation.feature
+++ b/extensions/exposition/features/identity.federation.feature
@@ -60,9 +60,11 @@ Feature: Identity Federation
       explicit_identity_creation: false
       trust:
         - issuer: http://localhost:44444
-          secret: the-secret
+          secrets:
+            HS384:
+              k1: the-secret
       """
-    And the IDP symmetric token for GoodUser is issued with following secret:
+    And the IDP HS384 token for GoodUser is issued with following secret:
       """
       the-secret
       """

--- a/extensions/exposition/features/steps/IdP.ts
+++ b/extensions/exposition/features/steps/IdP.ts
@@ -118,14 +118,14 @@ export class IdP {
     this.captures.set(`${user}.id_token`, idToken)
   }
 
-  @given('the IDP symmetric token for {word} is issued with following secret:')
-  public async issueSymmetricToken (user: string, secret: string): Promise<void> {
+  @given('the IDP {word} token for {word} is issued with following secret:')
+  public async issueSymmetricToken (alg: string, user: string, secret: string): Promise<void> {
     console.log('Sym token for %s with secret "%s"', user, secret)
 
     const jwt = [
       {
         typ: 'JWT',
-        alg: 'HS256'
+        alg
       },
       {
         iss: IdP.issuer,
@@ -138,7 +138,9 @@ export class IdP {
       .map((v) => Buffer.from(JSON.stringify(v)).toString('base64url'))
       .join('.')
 
-    const signature = crypto.createHmac('sha256', secret).update(jwt).digest('base64url')
+    const signature = crypto.createHmac(alg.replace(/^HS(\d{3})$/, 'sha$1'), secret)
+      .update(jwt)
+      .digest('base64url')
 
     const idToken = `${jwt}.${signature}`
 

--- a/extensions/exposition/features/steps/IdP.ts
+++ b/extensions/exposition/features/steps/IdP.ts
@@ -117,4 +117,31 @@ export class IdP {
 
     this.captures.set(`${user}.id_token`, idToken)
   }
+
+  @given('the IDP symmetric token for {word} is issued with following secret:')
+  public async issueSymmetricToken (user: string, secret: string): Promise<void> {
+    console.log('Sym token for %s with secret "%s"', user, secret)
+
+    const jwt = [
+      {
+        typ: 'JWT',
+        alg: 'HS256'
+      },
+      {
+        iss: IdP.issuer,
+        sub: `${user}-mock-id`,
+        aud: 'test',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor((Date.now() + 1000 * 60 * 5) / 1000)
+      }
+    ]
+      .map((v) => Buffer.from(JSON.stringify(v)).toString('base64url'))
+      .join('.')
+
+    const signature = crypto.createHmac('sha256', secret).update(jwt).digest('base64url')
+
+    const idToken = `${jwt}.${signature}`
+
+    this.captures.set(`${user}.id_token`, idToken)
+  }
 }


### PR DESCRIPTION
Implements support for `HS256` identity tokens with a pre-shared secret.