### PR TITLE
feat(exposition): add server timing

### DIFF
--- a/extensions/exposition/components/identity.bans/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.bans/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: identity
 name: bans
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/components/identity.basic/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.basic/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: identity
 name: basic
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/components/identity.federation/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.federation/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: identity
 name: federation
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/components/identity.roles/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.roles/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: identity
 name: roles
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/components/identity.tokens/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.tokens/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: identity
 name: tokens
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/components/octets.storage/manifest.toa.yaml
+++ b/extensions/exposition/components/octets.storage/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: octets
 name: storage
+version: 0.0.0
 
 storages: ~
 

--- a/extensions/exposition/features/steps/Gateway.ts
+++ b/extensions/exposition/features/steps/Gateway.ts
@@ -26,6 +26,9 @@ export class Gateway {
     if (annotation.debug === true)
       process.env.TOA_EXPOSITION_DEBUG = '1'
 
+    if (annotation.trace === true)
+      process.env.TOA_EXPOSITION_TRACE = '1'
+
     await Gateway.stop()
 
     this.default = false

--- a/extensions/exposition/features/steps/components/greeter/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/greeter/manifest.toa.yaml
@@ -1,4 +1,5 @@
 name: greeter
+version: 0.0.0
 
 exposition:
   /:

--- a/extensions/exposition/features/steps/components/pots/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/pots/manifest.toa.yaml
@@ -1,4 +1,5 @@
 name: pots
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/features/timing.feature
+++ b/extensions/exposition/features/timing.feature
@@ -25,7 +25,7 @@ Feature: Server timing
   Scenario: Server timing is sent when debug is enabled
     Given the annotation:
       """
-      debug: true
+      trace: true
       """
     When the following request is received:
       """

--- a/extensions/exposition/features/timing.feature
+++ b/extensions/exposition/features/timing.feature
@@ -39,5 +39,5 @@ Feature: Server timing
     Then the following reply is sent:
       """
       201 Created
-      server-timing: 1
+      server-timing:
       """

--- a/extensions/exposition/features/timing.feature
+++ b/extensions/exposition/features/timing.feature
@@ -1,0 +1,43 @@
+Feature: Server timing
+
+  Background:
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          POST: transit
+      """
+
+  Scenario: Server timing is not available by default
+    When the following request is received:
+      """
+      POST /pots/ HTTP/1.1
+      content-type: application/yaml
+
+      title: Hello
+      volume: 1.5
+      """
+    Then the reply does not contain:
+      """
+      server-timing:
+      """
+
+  Scenario: Server timing is sent when debug is enabled
+    Given the annotation:
+      """
+      debug: true
+      """
+    When the following request is received:
+      """
+      POST /pots/ HTTP/1.1
+      content-type: application/yaml
+
+      title: Hello
+      volume: 1.5
+      """
+    # to debug, break it and look at the console
+    Then the following reply is sent:
+      """
+      201 Created
+      server-timing: 1
+      """

--- a/extensions/exposition/readme.md
+++ b/extensions/exposition/readme.md
@@ -127,12 +127,12 @@ exposition:
   host: the.example.com
 ```
 
-| Option        | Type      | Description                                                      |
-|---------------|-----------|------------------------------------------------------------------|
-| `host`        | `string`  | Domain name to be used for the corresponding Kubernetes Ingress. |
-| `class`       | `string`  | Ingress class                                                    |
-| `annotations` | `object`  | Ingress annotations                                              |
-| `debug`       | `boolean` | Output server errors. Default `false`.                           |
+| Option        | Type      | Description                                                                                                                  |
+|---------------|-----------|------------------------------------------------------------------------------------------------------------------------------|
+| `host`        | `string`  | Domain name to be used for the corresponding Kubernetes Ingress.                                                             |
+| `class`       | `string`  | Ingress class                                                                                                                |
+| `annotations` | `object`  | Ingress annotations                                                                                                          |
+| `debug`       | `boolean` | Output server errors and [timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing). Default `false`. |
 
 ### Context resources
 

--- a/extensions/exposition/readme.md
+++ b/extensions/exposition/readme.md
@@ -127,12 +127,13 @@ exposition:
   host: the.example.com
 ```
 
-| Option        | Type      | Description                                                                                                                  |
-|---------------|-----------|------------------------------------------------------------------------------------------------------------------------------|
-| `host`        | `string`  | Domain name to be used for the corresponding Kubernetes Ingress.                                                             |
-| `class`       | `string`  | Ingress class                                                                                                                |
-| `annotations` | `object`  | Ingress annotations                                                                                                          |
-| `debug`       | `boolean` | Output server errors and [timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing). Default `false`. |
+| Option        | Type      | Description                                                                                                       |
+|---------------|-----------|-------------------------------------------------------------------------------------------------------------------|
+| `host`        | `string`  | Domain name to be used for the corresponding Kubernetes Ingress.                                                  |
+| `class`       | `string`  | Ingress class                                                                                                     |
+| `annotations` | `object`  | Ingress annotations                                                                                               |
+| `debug`       | `boolean` | Output server errors. Default `false`.                                                                            |
+| `trace`       | `boolean` | Output [server timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing). Default `false`. |
 
 ### Context resources
 

--- a/extensions/exposition/schemas/annotation.cos.yaml
+++ b/extensions/exposition/schemas/annotation.cos.yaml
@@ -2,4 +2,5 @@ host: string
 class: string
 annotations: <string>
 debug: boolean
+trace: boolean
 /: ~

--- a/extensions/exposition/source/Annotation.ts
+++ b/extensions/exposition/source/Annotation.ts
@@ -3,5 +3,6 @@ export interface Annotation {
   class?: string
   annotations?: Record<string, string>
   debug: boolean
+  trace: boolean
   '/'?: object // parsed and validated by RTD.syntax.parse
 }

--- a/extensions/exposition/source/Factory.ts
+++ b/extensions/exposition/source/Factory.ts
@@ -26,8 +26,9 @@ export class Factory implements extensions.Factory {
 
   public service (): Connector | null {
     const debug = process.env.TOA_EXPOSITION_DEBUG === '1'
+    const trace = process.env.TOA_EXPOSITION_TRACE === '1'
     const broadcast = this.boot.bindings.broadcast(CHANNEL)
-    const server = Server.create({ methods: syntax.verbs, debug })
+    const server = Server.create({ methods: syntax.verbs, debug, trace })
     const remotes = new Remotes(this.boot)
     const node = root.resolve()
     const methods = new EndpointsFactory(remotes)

--- a/extensions/exposition/source/HTTP/Server.fixtures.ts
+++ b/extensions/exposition/source/HTTP/Server.fixtures.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'stream'
+import { Timing } from './Timing'
 import type { IncomingMessage } from './messages'
 import type * as http from 'node:http'
 import type { NextFunction, Response, Express, Request } from 'express'
@@ -20,7 +21,12 @@ jest.MockedObject<IncomingMessage> {
   const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content)
   const stream = Readable.from(buffer)
 
-  Object.assign(stream, { headers: {} }, req)
+  const mock: Partial<IncomingMessage> = {
+    headers: {},
+    timing: new Timing(false)
+  }
+
+  Object.assign(stream, mock, req)
 
   return stream as unknown as jest.MockedObject<IncomingMessage>
 }

--- a/extensions/exposition/source/HTTP/Timing.ts
+++ b/extensions/exposition/source/HTTP/Timing.ts
@@ -1,0 +1,40 @@
+import { performance } from 'node:perf_hooks'
+import type { Response } from 'express'
+
+export class Timing {
+  private readonly skip: boolean
+  private readonly start = performance.now()
+  private readonly breakpoints: Breakpoint[] = []
+
+  public constructor (enabled: boolean) {
+    this.skip = !enabled
+  }
+
+  public async capture<T> (id: string, promise: Promise<T>): Promise<T> {
+    if (this.skip)
+      return promise
+
+    const start = performance.now()
+    const result = promise instanceof Promise ? await promise : promise
+
+    this.breakpoints.push({ id, duration: performance.now() - start })
+
+    return result
+  }
+
+  public append (response: Response): void {
+    if (this.skip)
+      return
+
+    this.breakpoints.push({ id: 'total', duration: performance.now() - this.start })
+
+    for (const breakpoint of this.breakpoints)
+      response.append('server-timing',
+        `${breakpoint.id};dur=${breakpoint.duration.toFixed(3)}`)
+  }
+}
+
+interface Breakpoint {
+  id: string
+  duration: number
+}

--- a/extensions/exposition/source/HTTP/messages.ts
+++ b/extensions/exposition/source/HTTP/messages.ts
@@ -4,9 +4,9 @@ import { type Request, type Response } from 'express'
 import { buffer } from '@toa.io/streams'
 import { formats } from './formats'
 import { BadRequest, NotAcceptable, UnsupportedMediaType } from './exceptions'
+import type { Format } from './formats'
 import type { Timing } from './Timing'
 import type { ParsedQs } from 'qs'
-import type { Format } from './formats'
 
 export function write
 (request: IncomingMessage, response: Response, message: OutgoingMessage): void {
@@ -35,9 +35,7 @@ export async function read (request: IncomingMessage): Promise<any> {
   const buf = await request.timing.capture('req:buffer', buffer(request))
 
   try {
-    const body = format.decode(buf)
-
-    return body
+    return format.decode(buf)
   } catch {
     throw new BadRequest()
   }

--- a/extensions/exposition/source/deployment.ts
+++ b/extensions/exposition/source/deployment.ts
@@ -41,6 +41,12 @@ export function deployment (_: unknown, annotation: Annotation | undefined): Dep
       value: '1'
     })
 
+  if (annotation?.trace === true)
+    service.variables.push({
+      name: 'TOA_EXPOSITION_TRACE',
+      value: '1'
+    })
+
   if (annotation !== undefined)
     schemas.annotaion.validate(annotation)
 

--- a/features/extensions/exposition/deployment.feature
+++ b/features/extensions/exposition/deployment.feature
@@ -49,3 +49,25 @@ Feature: Exposition deployment
           - name: TOA_MONGODB_IDENTITY_BASIC
             value: mongodb://database.url
       """
+
+  Scenario: Deploying `debug` and `trace` options
+    Given I have a context with:
+      """yaml
+      configuration:
+        identity.tokens:
+          key0: secret.key.0
+      exposition:
+        debug: true
+        trace: true
+      """
+    When I export deployment
+    Then exported values should contain:
+      """yaml
+      services:
+        - name: exposition-gateway
+          variables:
+          - name: TOA_EXPOSITION_DEBUG
+            value: "1"
+          - name: TOA_EXPOSITION_TRACE
+            value: "1"
+      """


### PR DESCRIPTION
Add [Server-Timing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing).

```http
200 OK
server-timing: gate:intercept;dur=0.058, gate:preflight;dur=0.014, req:buffer;dur=0.251, gate:call;dur=10.683, gate:settle;dur=0.003, total;dur=11.871
```