### PR TITLE
feat(configuration): add support for nested secrets

### DIFF
--- a/extensions/configuration/source/configuration.ts
+++ b/extensions/configuration/source/configuration.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import { type Locator } from '@toa.io/core'
 import { decode, add } from '@toa.io/generic'
 import * as schemas from '@toa.io/schemas'
@@ -44,8 +43,7 @@ function substituteSecrets (configuration: Node): void {
 
     const name = match.groups?.variable
 
-    assert.ok(name !== undefined)
-    configuration[key] = getSecret(name)
+    configuration[key] = getSecret(name!)
   }
 }
 

--- a/extensions/configuration/source/configuration.ts
+++ b/extensions/configuration/source/configuration.ts
@@ -6,7 +6,7 @@ import { PREFIX, SECRET_RX } from './deployment'
 import { type Manifest } from './manifest'
 import type { Schema } from '@toa.io/schemas'
 
-export function get (locator: Locator, manifest: Manifest): Configuration {
+export function get (locator: Locator, manifest: Manifest): Node {
   const values = getConfiguration(locator.uppercase)
 
   substituteSecrets(values)
@@ -21,16 +21,21 @@ export function get (locator: Locator, manifest: Manifest): Configuration {
   return values
 }
 
-function getConfiguration (suffix: string): Configuration {
+function getConfiguration (suffix: string): Node {
   const variable = PREFIX + suffix
   const string = process.env[variable]
 
-  if (string === undefined) return {}
-  else return decode(string)
+  if (string === undefined)
+    return {}
+  else
+    return decode(string)
 }
 
-function substituteSecrets (configuration: Configuration): void {
+function substituteSecrets (configuration: Node): void {
   for (const [key, value] of Object.entries(configuration)) {
+    if (typeof value === 'object' && value !== null)
+      substituteSecrets(value as Node)
+
     if (typeof value !== 'string') continue
 
     const match = value.match(SECRET_RX)
@@ -53,4 +58,4 @@ function getSecret (name: string): string {
   return value
 }
 
-export type Configuration = Record<string, any>
+export type Node = Record<string, unknown>

--- a/extensions/configuration/source/deployment.ts
+++ b/extensions/configuration/source/deployment.ts
@@ -36,6 +36,9 @@ function createSecrets (values: object): Variable[] {
   const secrets: Variable[] = []
 
   for (const value of Object.values(values)) {
+    if (typeof value === 'object' && value !== null)
+      secrets.push(...createSecrets(value))
+
     if (typeof value !== 'string') continue
 
     const match = value.match(SECRET_RX)

--- a/extensions/configuration/source/manifest.ts
+++ b/extensions/configuration/source/manifest.ts
@@ -1,5 +1,5 @@
 import * as schemas from './schemas'
-import { type Configuration } from './configuration'
+import { type Node } from './configuration'
 
 export function manifest (manifest: Manifest): Manifest {
   if (manifest.schema === undefined) manifest = { schema: manifest }
@@ -11,5 +11,5 @@ export function manifest (manifest: Manifest): Manifest {
 
 export interface Manifest {
   schema: object
-  defaults?: Configuration
+  defaults?: Node
 }

--- a/features/extensions/configuration.feature
+++ b/features/extensions/configuration.feature
@@ -42,12 +42,14 @@ Feature: Configuration Extension
       configuration:
         configuration.base:
           foo: bye
+          bar:
+            baz: bye
       """
     When I run `toa env`
     And I run `toa invoke echo -p ./components/configuration.base`
     And stdout should contain lines:
     """
-    { foo: 'bye' }
+    { foo: 'bye', baz: 'bye' }
     """
 
   Scenario: Secret values
@@ -57,16 +59,19 @@ Feature: Configuration Extension
       configuration:
         configuration.base:
           foo: $FOO_SECRET_VALUE
+          bar:
+            baz: $BAZ_SECRET_VALUE
       """
     When I run `toa env`
     And I update an environment with:
       """
-      TOA_CONFIGURATION__FOO_SECRET_VALUE=super secret password
+      TOA_CONFIGURATION__FOO_SECRET_VALUE=secret foo
+      TOA_CONFIGURATION__BAZ_SECRET_VALUE=secret baz
       """
     And I run `toa invoke echo -p ./components/configuration.base`
     And stdout should contain lines:
     """
-    { foo: 'super secret password' }
+    { foo: 'secret foo', baz: 'secret baz' }
     """
 
   Scenario: Deployment
@@ -94,6 +99,8 @@ Feature: Configuration Extension
       configuration:
         configuration.base:
           foo: $FOO_VALUE
+          bar:
+            baz: $BAZ_VALUE
       """
     When I export deployment
     Then exported values should contain:
@@ -102,11 +109,15 @@ Feature: Configuration Extension
         - name: configuration-base
           variables:
             - name: TOA_CONFIGURATION_CONFIGURATION_BASE
-              value: eyJmb28iOiIkRk9PX1ZBTFVFIn0=
+              value: eyJmb28iOiIkRk9PX1ZBTFVFIiwiYmFyIjp7ImJheiI6IiRCQVpfVkFMVUUifX0=
             - name: TOA_CONFIGURATION__FOO_VALUE
               secret:
                 name: toa-configuration
                 key: FOO_VALUE
+            - name: TOA_CONFIGURATION__BAZ_VALUE
+              secret:
+                name: toa-configuration
+                key: BAZ_VALUE
       """
 
   Scenario: Shared secret deployment

--- a/features/steps/.workspace/components/collection/configuration.array/manifest.toa.yaml
+++ b/features/steps/.workspace/components/collection/configuration.array/manifest.toa.yaml
@@ -1,5 +1,5 @@
 namespace: configuration
-name: base
+name: array
 
 operations:
   greet:

--- a/features/steps/.workspace/components/collection/configuration.array/operations/greet.js
+++ b/features/steps/.workspace/components/collection/configuration.array/operations/greet.js
@@ -1,9 +1,10 @@
 'use strict'
 
 async function computation (input, context) {
-  const greetings = context.configuration.greetings
-  const greeting = greetings[input]
-  const { a, b } = greeting
+  const {
+    a,
+    b
+  } = context.configuration.greetings[input]
 
   return `${a} ${b}`
 }

--- a/features/steps/.workspace/components/collection/configuration.base/manifest.toa.yaml
+++ b/features/steps/.workspace/components/collection/configuration.base/manifest.toa.yaml
@@ -9,3 +9,5 @@ operations:
 configuration:
   schema:
     foo: hello
+    bar:
+      baz: world

--- a/features/steps/.workspace/components/collection/configuration.base/operations/echo.js
+++ b/features/steps/.workspace/components/collection/configuration.base/operations/echo.js
@@ -5,6 +5,10 @@ async function computation (input, context) {
 
   output.foo = context.configuration.foo
 
+  if (context.configuration.bar?.baz) {
+    output.baz = context.configuration.bar.baz
+  }
+
   return output
 }
 

--- a/features/steps/output.js
+++ b/features/steps/output.js
@@ -8,7 +8,7 @@ Then('{word} should be the version',
    * @param {string} channel
    * @this {toa.features.Context}
    */
-  async function (channel) {
+  async function(channel) {
     const { version } = require('@toa.io/runtime')
 
     await this.process
@@ -16,41 +16,41 @@ Then('{word} should be the version',
     assert.equal(this[channel], version)
   })
 
-Then('{word} should contain {int} line(s)', async function (channel, lines) {
+Then('{word} should contain {int} line(s)', async function(channel, lines) {
   await this.process
 
   assert.equal(this[channel + 'Lines'].length, lines, `${channel} contains ${this[channel].length} lines, ${lines} expected`)
 })
 
-Then('{word} should be empty', async function (channel) {
+Then('{word} should be empty', async function(channel) {
   await this.process
 
   assert.equal(this[channel], '')
 })
 
 Then('{word} should contain line(s):',
-  async function (channel, lines) {
+  async function(channel, lines) {
     await this.process
 
     find(this, channel, lines)
   })
 
 Then('{word} should not contain line(s):',
-  async function (channel, lines) {
+  async function(channel, lines) {
     await this.process
 
     find(this, channel, lines, undefined, true)
   })
 
 Then('{word} should contain line(s) once:',
-  async function (channel, lines) {
+  async function(channel, lines) {
     await this.process
 
     find(this, channel, lines, 1)
   })
 
 Then('{word} should be: {string}',
-  async function (channel, line) {
+  async function(channel, line) {
     await this.process
 
     const actual = this[channel]
@@ -72,9 +72,9 @@ const find = (context, channel, lines, exact = undefined, reverse = false) => {
 
   /** @type {number[]} */
   const count = []
+  const output = context[channel + 'Lines']
 
   for (const query of queries) {
-    const output = context[channel + 'Lines']
     let matches = 0
 
     for (const line of output) {
@@ -111,8 +111,11 @@ const compare = (reference, line) => {
 }
 
 function substituteExpression (expression) {
-  if (!(expression in expressions)) return expression
-  else return expressions[expression]
+  if (!(expression in expressions)) {
+    return expression
+  } else {
+    return expressions[expression]
+  }
 }
 
 const expressions = {


### PR DESCRIPTION
Currently, configuration secrets resolved only on the top level properties.

The PR will allow the following:

```
configuration:
  component:
    foo:
      bar: $SECRET
```