### PR TITLE
feat(exposition)!: add I/O restrictions

### DIFF
--- a/extensions/exposition/components/identity.basic/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.basic/manifest.toa.yaml
@@ -42,9 +42,11 @@ configuration:
 exposition:
   isolated: true
   /:
+    io:output: [id]
     anonymous: true
     POST: incept
   /:id:
+    io:output: [id]
     auth:role: system:identity:basic
     auth:scheme: basic
     auth:id: id

--- a/extensions/exposition/components/identity.federation/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.federation/manifest.toa.yaml
@@ -93,9 +93,3 @@ configuration:
           - sub
         additionalProperties: false
     additionalProperties: false
-
-exposition:
-  isolated: true
-  /:
-    anonymous: true
-    POST: incept

--- a/extensions/exposition/components/identity.roles/manifest.toa.yaml
+++ b/extensions/exposition/components/identity.roles/manifest.toa.yaml
@@ -28,5 +28,6 @@ exposition:
     auth:role: system:identity:roles
     POST: transit
     GET:
+      io:output: true
       auth:id: identity
       endpoint: list

--- a/extensions/exposition/documentation/io.md
+++ b/extensions/exposition/documentation/io.md
@@ -1,0 +1,47 @@
+# I/O restrictions
+
+The Exposition comes with `io` directives to control access to the operation's input and output
+properties.
+
+## `io:input`
+
+The `io:input` optional directive contains a list of properties that are allowed to be specified in
+the request body.
+
+```yaml
+POST:
+  endpoint: create
+  io:input: [name, location]
+```
+
+The list must be a valid subset of the operation's input properties.
+
+If `io:input` is specified and the request body is not an object, or contains properties that are
+not in the list, the request will be rejected with a `400` status code.
+
+> Therefore, `io:input` is only applicable to operations which input is an object or an
+> array of objects.
+
+## `io:output`
+
+The `io:output` mandatory directive contains a list of properties that are allowed to be included in
+the response body.
+
+```yaml
+GET:
+  endpoint: observe
+  io:output: [name, location]
+```
+
+A method declaration without `io:output` will cause a startup warning, and its response will always
+be empty with a `204` status code.
+
+When an operation does not return an object (e.g., a primitive or a stream), or an object is dynamic
+and its properties are not known in advance, `io:output` may have a value of `true` to disable
+output restrictions.
+
+```yaml
+GET:
+  endpoint: proxy
+  io:output: true
+```

--- a/extensions/exposition/documentation/io.md
+++ b/extensions/exposition/documentation/io.md
@@ -52,3 +52,5 @@ GET:
   endpoint: conceal
   io:output: false
 ```
+
+Output restrictions are not applied to stream responses and errors.

--- a/extensions/exposition/documentation/io.md
+++ b/extensions/exposition/documentation/io.md
@@ -44,7 +44,7 @@ GET:
 ```
 
 If a method declaration lacks `io:output` directive, it will trigger a warning, and its
-response will consistently be empty with a `204` status code.
+response will consistently be empty.
 If this behavior is intended, a `false` value can be employed to suppress warnings.
 
 ```yaml

--- a/extensions/exposition/documentation/io.md
+++ b/extensions/exposition/documentation/io.md
@@ -33,9 +33,6 @@ GET:
   io:output: [name, location]
 ```
 
-A method declaration without `io:output` will cause a startup warning, and its response will always
-be empty with a `204` status code.
-
 When an operation does not return an object (e.g., a primitive or a stream), or an object is dynamic
 and its properties are not known in advance, `io:output` may have a value of `true` to disable
 output restrictions.
@@ -44,4 +41,14 @@ output restrictions.
 GET:
   endpoint: proxy
   io:output: true
+```
+
+If a method declaration lacks `io:output` directive, it will trigger a warning, and its
+response will consistently be empty with a `204` status code.
+If this behavior is intended, a `false` value can be employed to suppress warnings.
+
+```yaml
+GET:
+  endpoint: conceal
+  io:output: false
 ```

--- a/extensions/exposition/documentation/query.md
+++ b/extensions/exposition/documentation/query.md
@@ -6,10 +6,10 @@
 id?: string
 criteria?: string
 sort?: string
-omit?: [integer]
-limit?: [integer]
+omit?: integer
+limit?: integer
 selectors?: string[]
-projection?: [string]
+projection?: string[]
 ```
 
 ```yaml
@@ -251,9 +251,9 @@ PUT /dummies/5e82ed5e/ HTTP/1.1
 if-match: "1"
 
 foo: baz
+```
 
----
-
+```http
 200 OK
 ```
 
@@ -262,8 +262,10 @@ PUT /dummies/5e82ed5e/ HTTP/1.1
 if-match: "never"
 
 foo: baz
+```
 
----
-
+```http
 412 Precondition Failed
 ```
+
+The value within the quotes is mapped to the `version` property of operation call query.

--- a/extensions/exposition/documentation/tree.md
+++ b/extensions/exposition/documentation/tree.md
@@ -102,7 +102,7 @@ HTTP methods can only be mapped to operations of the corresponding types.
 | `GET`       | **Observation**<br/>**Computation**           |
 | `PATCH`     | **Assignment**<br/>**Effect**                 |
 
-As method mapping is unambiguous for Observation, Assignent, and Computation, a consice syntax is
+As method mapping is unambiguous for Observation, Assignment, and Computation, a concise syntax is
 available:
 
 ```yaml
@@ -110,7 +110,23 @@ available:
 /items/:id: [observe, assign]
 ```
 
-### Intermediate Nodes
+### Projections
+
+A Method can have a `projection` key that specifies the fields of the operation result to be
+included in the response.
+
+```yaml
+/teapots:
+  GET:
+    endpoint: select
+    projection:
+      - name
+      - state
+```
+
+> `id` is always included in the projection.
+
+## Intermediate Nodes
 
 An RTD Node that has a Route with a key `/` is an _intermediate_ Node.
 Intermediate Nodes must not have Methods as they are unreachable.
@@ -124,8 +140,10 @@ Intermediate Nodes must not have Methods as they are unreachable.
 
 ## Directives
 
-RTD Directives are declared using RTD node or Method keys following the `{family}:{directive}` pattern and can be used
-to add or modify the behavior of request processing. Directive declarations are applied to the RTD node where they are
+RTD Directives are declared using RTD node or Method keys following the `{family}:{directive}`
+pattern and can be used
+to add or modify the behavior of request processing. Directive declarations are applied to the RTD
+node where they are
 declared and to all nested nodes.
 
 ```yaml

--- a/extensions/exposition/features/access.feature
+++ b/extensions/exposition/features/access.feature
@@ -30,6 +30,7 @@ Feature: Access authorization
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:anonymous: true
         GET:
           dev:stub:
@@ -71,6 +72,7 @@ Feature: Access authorization
     Given the annotation:
       """yaml
       /:
+        io:output: true
         /:id:
           auth:id: id
           GET:
@@ -109,6 +111,7 @@ Feature: Access authorization
     And the annotation:
       """yaml
       /:
+        io:output: true
         auth:role: developer
         GET:
           dev:stub:
@@ -146,6 +149,7 @@ Feature: Access authorization
     And the annotation:
       """yaml
       /:
+        io:output: true
         /:
           auth:role: developer:rust:junior  # role scope matches
           /nested:
@@ -190,6 +194,7 @@ Feature: Access authorization
           - developer
           - admin
         GET:
+          io:output: true
           dev:stub:
             access: granted!
       """
@@ -215,6 +220,7 @@ Feature: Access authorization
     And the annotation:
       """yaml
       /:
+        io:output: true
         /rust/:id:
           auth:rule:
             id: id
@@ -257,6 +263,7 @@ Feature: Access authorization
     Given the annotation:
       """yaml
       /:
+        io:output: true
         /:id:
           auth:id: id
           GET:
@@ -295,6 +302,7 @@ Feature: Access authorization
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:role: developer
         GET:
           dev:stub:
@@ -335,6 +343,7 @@ Feature: Access authorization
     Given the annotation:
       """yaml
       /:
+        io:output: true
         /:id:
           auth:scheme: basic
           auth:id: id
@@ -374,7 +383,8 @@ Feature: Access authorization
 
     Given the annotation:
       """yaml
-      anonymous: true
+      /:
+        anonymous: true
       """
     When the following request is received:
       """

--- a/extensions/exposition/features/annotation.feature
+++ b/extensions/exposition/features/annotation.feature
@@ -4,6 +4,7 @@ Feature: Annotation
     Given the annotation:
       """yaml
       /:
+        io:output: true
         anonymous: true
         /foo:
           GET:

--- a/extensions/exposition/features/body.feature
+++ b/extensions/exposition/features/body.feature
@@ -25,6 +25,7 @@ Feature: Request body
       """yaml
       exposition:
         /:name:
+          io:output: true
           GET: <operation>
       """
     When the following request is received:

--- a/extensions/exposition/features/cache.feature
+++ b/extensions/exposition/features/cache.feature
@@ -14,6 +14,7 @@ Feature: Caching
     Given the annotation:
       """yaml
       /:
+        io:output: true
         anonymous: true
         GET:
           cache:control: max-age=60000
@@ -37,6 +38,7 @@ Feature: Caching
     Given the annotation:
       """yaml
       /:
+        io:output: true
         cache:control: max-age=30000
         GET:
           anonymous: true
@@ -120,6 +122,7 @@ Feature: Caching
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:role: developer
         cache:exact: max-age=60000, public
         GET:

--- a/extensions/exposition/features/directives.feature
+++ b/extensions/exposition/features/directives.feature
@@ -4,6 +4,7 @@ Feature: Directives
     Given the annotation:
       """yaml
       /:
+        io:output: true
         anonymous: true
         GET:
           dev:stub:
@@ -26,6 +27,7 @@ Feature: Directives
     Given the annotation:
       """yaml
       /:
+        io:output: true
         anonymous: true
         dev:stub:
           hello: again

--- a/extensions/exposition/features/dynamic.feature
+++ b/extensions/exposition/features/dynamic.feature
@@ -11,6 +11,7 @@ Feature: Dynamic tree updates
       """yaml
       exposition:
         /:
+          io:output: true
           isolated: true
           GET: enumerate
       """
@@ -27,6 +28,7 @@ Feature: Dynamic tree updates
       """yaml
       exposition:
         /:
+          io:output: true
           GET: enumerate
       """
     When the following request is received:
@@ -44,19 +46,22 @@ Feature: Dynamic tree updates
       """yaml
       exposition:
         /:id:
+          io:output: true
           GET: observe
       """
     Then the `pots` is stopped
     Then the `pots` is running with the following manifest:
       """yaml
       exposition:
-        /:id:
-          GET: observe
-        /big:
-          GET:
-            endpoint: enumerate
-            query:
-              criteria: volume>200
+        /:
+          io:output: true
+          /:id:
+            GET: observe
+          /big:
+            GET:
+              endpoint: enumerate
+              query:
+                criteria: volume>200
       """
     When the following request is received:
       """
@@ -73,6 +78,7 @@ Feature: Dynamic tree updates
       """yaml
       exposition:
         /big:
+          io:output: true
           GET:
             endpoint: enumerate
             query:
@@ -83,6 +89,7 @@ Feature: Dynamic tree updates
       """yaml
       exposition:
         /big:
+          io:output: true
           GET:
             endpoint: enumerate
             query:

--- a/extensions/exposition/features/errors.feature
+++ b/extensions/exposition/features/errors.feature
@@ -46,7 +46,7 @@ Feature: Errors
       accept: application/yaml
       """
     Then the following reply is sent:
-      """http
+      """
       405 Method Not Allowed
       """
 
@@ -57,7 +57,7 @@ Feature: Errors
       accept: application/yaml
       """
     Then the following reply is sent:
-      """http
+      """
       501 Not Implemented
       """
 
@@ -197,6 +197,7 @@ Feature: Errors
       """yaml
       /:
         GET:
+          io:output: true
           anonymous: true
           dev:stub: hello
       """

--- a/extensions/exposition/features/etag.feature
+++ b/extensions/exposition/features/etag.feature
@@ -5,6 +5,7 @@ Feature: Optimistic concurrency control
       """yaml
       exposition:
         /:
+          io:output: true
           POST: create
           /:id:
             GET: observe

--- a/extensions/exposition/features/identity.basic.feature
+++ b/extensions/exposition/features/identity.basic.feature
@@ -22,6 +22,7 @@ Feature: Basic authentication
       """yaml
       exposition:
         /:
+          io:output: true
           anonymous: true     # checking compatibility with anonymous access
           POST:
             incept: id
@@ -72,6 +73,7 @@ Feature: Basic authentication
     Given the annotation:
       """yaml
       /:
+        io:output: true
         /:id:
           id: id
           GET:
@@ -113,6 +115,25 @@ Feature: Basic authentication
     Then the following reply is sent:
       """
       200 OK
+      """
+
+  Scenario: Changing other identity the password
+    Given the `identity.basic` database contains:
+      | _id                              | username  | password                                                     | _version |
+      | efe3a65ebbee47ed95a73edd911ea328 | developer | $2b$10$ZRSKkgZoGnrcTNA5w5eCcu3pxDzdTduhteVYXcp56AaNcilNkwJ.O | 1        |
+      | 6c0be50cbfb043acafe69cc7d3895f84 | attacker  | $2b$10$ZRSKkgZoGnrcTNA5w5eCcu3pxDzdTduhteVYXcp56AaNcilNkwJ.O | 1        |
+    When the following request is received:
+      """
+      PATCH /identity/basic/efe3a65ebbee47ed95a73edd911ea328/ HTTP/1.1
+      authorization: Basic YXR0YWNrZXI6c2VjcmV0
+      accept: application/yaml
+      content-type: application/yaml
+
+      password: new-secret
+      """
+    Then the following reply is sent:
+      """
+      403 Forbidden
       """
 
   Scenario Outline: <problem> not meeting the requirements
@@ -173,6 +194,7 @@ Feature: Basic authentication
     And the annotation:
       """yaml
       /:
+        io:output: true
         GET:
           auth:role: system:stub
           dev:stub:
@@ -244,6 +266,7 @@ Feature: Basic authentication
       """yaml
       exposition:
         /:
+          io:output: true
           anonymous: true
           POST:
             incept: id

--- a/extensions/exposition/features/identity.federation.feature
+++ b/extensions/exposition/features/identity.federation.feature
@@ -4,7 +4,6 @@ Feature: Identity Federation
     Given the `identity.federation` database is empty
     Given local IDP is running
 
-
   Scenario: Getting identity for a new user
     Given the `identity.federation` configuration:
       """yaml
@@ -27,9 +26,9 @@ Feature: Identity Federation
 
       id: ${{ User.id }}
       roles: []
-      scheme: bearer
+      scheme: BEARER
       """
-    # validate token
+    # validate TOKEN
     When the following request is received:
       """
       GET /identity/ HTTP/1.1

--- a/extensions/exposition/features/identity.roles.feature
+++ b/extensions/exposition/features/identity.roles.feature
@@ -11,6 +11,7 @@ Feature: Roles management
     And the annotation:
       """yaml
       /:
+        io:output: true
         auth:role: test
         GET:
           dev:stub:

--- a/extensions/exposition/features/identity.tokens.feature
+++ b/extensions/exposition/features/identity.tokens.feature
@@ -7,6 +7,7 @@ Feature: Tokens lifecycle
     Given the annotation:
       """yaml
       /:
+        io:output: true
         /hello/:id:
           auth:id: id
           GET:
@@ -35,6 +36,7 @@ Feature: Tokens lifecycle
     And the annotation:
       """yaml
       /:
+        io:output: true
         /hello/:id:
           auth:id: id
           GET:
@@ -72,6 +74,7 @@ Feature: Tokens lifecycle
     Given the annotation:
       """yaml
       /:
+        io:output: true
         /:id:
           id: id
           GET:

--- a/extensions/exposition/features/io.feature
+++ b/extensions/exposition/features/io.feature
@@ -6,7 +6,27 @@ Feature: IO restrictions
       | 4c4759e6f9c74da989d64511df42d6f4 | First pot  | 100    | 80          |
       | 99988d785d7d445cad45dbf8531f560b | Second pot | 200    | 30          |
 
-  Scenario: Output restrictions
+  Scenario: Output is omitted by default
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          GET: enumerate
+          /:id:
+            GET: observe
+      """
+    When the following request is received:
+      """
+      GET /pots/4c4759e6f9c74da989d64511df42d6f4/ HTTP/1.1
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      content-length: 0
+      """
+
+  Scenario: Output permissions
     Given the `pots` is running with the following manifest:
       """yaml
       exposition:

--- a/extensions/exposition/features/io.feature
+++ b/extensions/exposition/features/io.feature
@@ -18,6 +18,34 @@ Feature: IO restrictions
     When the following request is received:
       """
       GET /pots/4c4759e6f9c74da989d64511df42d6f4/ HTTP/1.1
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      content-length: 0
+      """
+    When the following request is received:
+      """
+      GET /pots/ HTTP/1.1
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      content-length: 0
+      """
+
+  Scenario: Output is omitted by intention
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:id:
+          io:output: false
+          GET: observe
+      """
+    When the following request is received:
+      """
+      GET /pots/4c4759e6f9c74da989d64511df42d6f4/ HTTP/1.1
       accept: application/yaml
       """
     Then the following reply is sent:
@@ -72,4 +100,68 @@ Feature: IO restrictions
       """
       title:
       temperature:
+      """
+
+  Scenario: Input is unrestricted by default
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          io:output: true
+          POST: create
+      """
+    When the following request is received:
+      """
+      POST /pots/ HTTP/1.1
+      accept: application/yaml
+      content-type: application/yaml
+
+      title: Hello
+      volume: 1.5
+      temperature: 80
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+
+      title: Hello
+      volume: 1.5
+      temperature: 80
+      """
+
+  Scenario: Input permissions
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          io:input: [title, volume]
+          POST: create
+      """
+    When the following request is received:
+      """
+      POST /pots/ HTTP/1.1
+      accept: text/plain
+      content-type: application/yaml
+
+      title: Hello
+      volume: 1.5
+      temperature: 80
+      """
+    Then the following reply is sent:
+      """
+      400 Bad Request
+
+      Unexpected input: temperature
+      """
+    When the following request is received:
+      """
+      POST /pots/ HTTP/1.1
+      content-type: application/yaml
+
+      title: Hello
+      volume: 1.5
+      """
+    Then the following reply is sent:
+      """
+      201 Created
       """

--- a/extensions/exposition/features/io.feature
+++ b/extensions/exposition/features/io.feature
@@ -1,0 +1,37 @@
+Feature: IO restrictions
+
+  Background:
+    Given the `pots` database contains:
+      | _id                              | title      | volume | temperature |
+      | 4c4759e6f9c74da989d64511df42d6f4 | First pot  | 100    | 80          |
+      | 99988d785d7d445cad45dbf8531f560b | Second pot | 200    | 30          |
+
+  Scenario: Array response with output restriction
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          GET:
+            endpoint: enumerate
+            io:output: [id, volume]
+      """
+    When the following request is received:
+      """
+      GET /pots/ HTTP/1.1
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      content-type: application/yaml
+
+      - id: 4c4759e6f9c74da989d64511df42d6f4
+        volume: 100
+      - id: 99988d785d7d445cad45dbf8531f560b
+        volume: 200
+      """
+    And the reply does not contain:
+      """
+      title:
+      temperature:
+      """

--- a/extensions/exposition/features/io.feature
+++ b/extensions/exposition/features/io.feature
@@ -6,14 +6,32 @@ Feature: IO restrictions
       | 4c4759e6f9c74da989d64511df42d6f4 | First pot  | 100    | 80          |
       | 99988d785d7d445cad45dbf8531f560b | Second pot | 200    | 30          |
 
-  Scenario: Array response with output restriction
+  Scenario: Output restrictions
     Given the `pots` is running with the following manifest:
       """yaml
       exposition:
         /:
-          GET:
-            endpoint: enumerate
-            io:output: [id, volume]
+          io:output: [id, volume]
+          GET: enumerate
+          /:id:
+            GET: observe
+      """
+    When the following request is received:
+      """
+      GET /pots/4c4759e6f9c74da989d64511df42d6f4/ HTTP/1.1
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+
+      id: 4c4759e6f9c74da989d64511df42d6f4
+      volume: 100
+      """
+    And the reply does not contain:
+      """
+      title:
+      temperature:
       """
     When the following request is received:
       """

--- a/extensions/exposition/features/octets.entries.feature
+++ b/extensions/exposition/features/octets.entries.feature
@@ -4,6 +4,7 @@ Feature: Accessing entries
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:anonymous: true
         octets:context: octets
         POST:
@@ -50,6 +51,7 @@ Feature: Accessing entries
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:anonymous: true
         octets:context: octets
         POST:

--- a/extensions/exposition/features/octets.feature
+++ b/extensions/exposition/features/octets.feature
@@ -4,6 +4,7 @@ Feature: Octets directive family
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:anonymous: true
         octets:context: octets
         POST:
@@ -238,6 +239,7 @@ Feature: Octets directive family
     Given the annotation:
       """yaml
       /:
+        io:output: true
         auth:anonymous: true
         octets:context: octets
         POST:

--- a/extensions/exposition/features/octets.meta.feature
+++ b/extensions/exposition/features/octets.meta.feature
@@ -5,6 +5,7 @@ Feature: Octets `content-meta` header
     And the annotation:
       """yaml
       /:
+        io:output: true
         auth:anonymous: true
         octets:context: octets
         /*:
@@ -55,11 +56,11 @@ Feature: Octets `content-meta` header
     When the following request is received:
       """
       OPTIONS / HTTP/1.1
-      origin: http://example.com
+      origin: https://example.com
       """
     Then the following reply is sent:
       """
       204 No Content
-      access-control-allow-origin: http://example.com
-      access-control-allow-headers: accept, authorization, content-type, content-meta
+      access-control-allow-origin: https://example.com
+      access-control-allow-headers: accept, authorization, content-type, etag, if-match, if-none-match, content-meta
       """

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -15,6 +15,7 @@ Feature: Octets storage workflows
               - add-baz: octets.tester.baz
               - diversify: octets.tester.diversify
         /*:
+          io:output: true
           GET:
             octets:fetch:
               meta: true

--- a/extensions/exposition/features/queries.feature
+++ b/extensions/exposition/features/queries.feature
@@ -212,31 +212,3 @@ Feature: Queries
         volume: 100
         temperature: 80
       """
-
-  Scenario: Request with projection
-    Given the `pots` is running with the following manifest:
-      """yaml
-      exposition:
-        /:
-          GET:
-            endpoint: enumerate
-            projection: [volume, temperature]
-      """
-    When the following request is received:
-      """
-      GET /pots/?id=4c4759e6f9c74da989d64511df42d6f4 HTTP/1.1
-      accept: application/yaml
-      """
-    Then the following reply is sent:
-      """
-      200 OK
-      content-type: application/yaml
-
-      - id: 4c4759e6f9c74da989d64511df42d6f4
-        volume: 100
-        temperature: 80
-      """
-    And the reply does not contain:
-      """
-      title:
-      """

--- a/extensions/exposition/features/queries.feature
+++ b/extensions/exposition/features/queries.feature
@@ -127,7 +127,7 @@ Feature: Queries
       volume: 200
       """
 
-  Scenario: Request to a route with predefined criretia
+  Scenario: Request to a route with predefined criteria
     Given the `pots` is running with the following manifest:
       """yaml
       exposition:
@@ -211,4 +211,32 @@ Feature: Queries
         title: First pot
         volume: 100
         temperature: 80
+      """
+
+  Scenario: Request with projection
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          GET:
+            endpoint: enumerate
+            projection: [volume, temperature]
+      """
+    When the following request is received:
+      """
+      GET /pots/?id=4c4759e6f9c74da989d64511df42d6f4 HTTP/1.1
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      content-type: application/yaml
+
+      - id: 4c4759e6f9c74da989d64511df42d6f4
+        volume: 100
+        temperature: 80
+      """
+    And the reply does not contain:
+      """
+      title:
       """

--- a/extensions/exposition/features/queries.feature
+++ b/extensions/exposition/features/queries.feature
@@ -13,6 +13,7 @@ Feature: Queries
       """yaml
       exposition:
         /pot:
+          io:output: true
           GET: observe
       """
     When the following request is received:
@@ -35,6 +36,7 @@ Feature: Queries
       """yaml
       exposition:
         /:
+          io:output: true
           GET: enumerate
       """
     When the following request is received:
@@ -60,6 +62,7 @@ Feature: Queries
       """yaml
       exposition:
         /:
+          io:output: true
           GET: enumerate
       """
     When the following request is received:
@@ -85,6 +88,7 @@ Feature: Queries
       """yaml
       exposition:
         /:
+          io:output: true
           GET: enumerate
       """
     When the following request is received:
@@ -110,6 +114,7 @@ Feature: Queries
       """yaml
       exposition:
         /:id:
+          io:output: true
           GET: observe
       """
     When the following request is received:
@@ -132,6 +137,7 @@ Feature: Queries
       """yaml
       exposition:
         /big:
+          io:output: true
           GET:
             endpoint: enumerate
             query:
@@ -160,6 +166,7 @@ Feature: Queries
       """yaml
       exposition:
         /big:
+          io:output: true
           GET:
             endpoint: enumerate
             query:
@@ -186,6 +193,7 @@ Feature: Queries
       """yaml
       exposition:
         /hottest2:
+          io:output: true
           GET:
             endpoint: enumerate
             query:

--- a/extensions/exposition/features/response.feature
+++ b/extensions/exposition/features/response.feature
@@ -4,6 +4,7 @@ Feature: Response
     Given the annotation:
       """yaml
       /:
+        io:output: true
         GET:
           anonymous: true
           dev:stub: hello
@@ -25,6 +26,7 @@ Feature: Response
       """yaml
       exposition:
         /:
+          io:output: true
           GET: error
       """
     When the following request is received:
@@ -46,6 +48,7 @@ Feature: Response
       """yaml
       exposition:
         /:
+          io:output: true
           GET: error
       """
     When the following request is received:

--- a/extensions/exposition/features/routes.feature
+++ b/extensions/exposition/features/routes.feature
@@ -6,12 +6,14 @@ Feature: Routes
       namespace: basic
 
       exposition:
-        /strict:
-          GET:
-            endpoint: greet
-        /shortcuts:
-          /operation:
-            GET: greet
+        /:
+          io:output: true
+          /strict:
+            GET:
+              endpoint: greet
+          /shortcuts:
+            /operation:
+              GET: greet
       """
     When the following request is received:
       """
@@ -34,6 +36,7 @@ Feature: Routes
       """yaml
       exposition:
         /:
+          io:output: true
           GET: greet
       """
     When the following request is received:
@@ -52,10 +55,12 @@ Feature: Routes
     Given the `greeter` is running with the following manifest:
       """yaml
       exposition:
-        /*:
-          GET: greet
-        /foo/*/bar:
-          GET: greet
+        /:
+          io:output: true
+          /*:
+            GET: greet
+          /foo/*/bar:
+            GET: greet
       """
     When the following request is received:
       """
@@ -94,12 +99,14 @@ Feature: Routes
       """yaml
       exposition:
         /:
+          io:output: true
           POST: create
       """
     And the `users.properties` is running with the following manifest:
       """yaml
       exposition:
         /:id:
+          io:output: true
           GET: observe
       """
     When the following request is received:

--- a/extensions/exposition/features/steps/components/pots/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/pots/manifest.toa.yaml
@@ -14,11 +14,13 @@ operations:
     input:
       title*: .
       volume*: .
+      temperature: .
   transit:
     concurrency: retry
     input:
       title: .
       volume: .
+      temperature: .
   observe:
     output:
       id: string

--- a/extensions/exposition/features/steps/components/users.properties/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/users.properties/manifest.toa.yaml
@@ -1,5 +1,6 @@
 namespace: users
 name: properties
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/features/steps/components/users/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/users/manifest.toa.yaml
@@ -1,4 +1,5 @@
 name: users
+version: 0.0.0
 
 entity:
   schema:

--- a/extensions/exposition/features/vary.feature
+++ b/extensions/exposition/features/vary.feature
@@ -5,6 +5,7 @@ Feature: The Vary directive family
       """yaml
       exposition:
         /:
+          io:output: true
           vary:languages: [en, fr]
           GET:
             vary:embed:
@@ -43,6 +44,7 @@ Feature: The Vary directive family
       """yaml
       exposition:
         /:
+          io:output: true
           GET:
             anonymous: true
             vary:embed:
@@ -68,6 +70,7 @@ Feature: The Vary directive family
       """yaml
       exposition:
         /:
+          io:output: true
           GET:
             vary:embed:
               name: :foo
@@ -93,6 +96,7 @@ Feature: The Vary directive family
         """yaml
         exposition:
           /:
+            io:output: true
             vary:languages: [en, fr]
             GET:
               vary:embed:
@@ -127,6 +131,7 @@ Feature: The Vary directive family
         """yaml
         exposition:
           /:
+            io:output: true
             vary:languages: [en, fr]
             GET:
               vary:embed:
@@ -140,11 +145,11 @@ Feature: The Vary directive family
     When the following request is received:
         """
         OPTIONS / HTTP/1.1
-        origin: http://example.com
+        origin: https://example.com
         access-control-request-headers: whatever
         """
     Then the following reply is sent:
         """
         204 No Content
-        access-control-allow-headers: accept, authorization, content-type, accept-language, foo, bar
+        access-control-allow-headers: accept, authorization, content-type, etag, if-match, if-none-match, accept-language, foo, bar
         """

--- a/extensions/exposition/schemas/io/input.cos.yaml
+++ b/extensions/exposition/schemas/io/input.cos.yaml
@@ -1,0 +1,3 @@
+type: array
+items:
+  type: string

--- a/extensions/exposition/schemas/io/message.cos.yaml
+++ b/extensions/exposition/schemas/io/message.cos.yaml
@@ -1,0 +1,5 @@
+oneOf:
+  - type: object
+  - type: array
+    items:
+      type: object

--- a/extensions/exposition/schemas/io/output.cos.yaml
+++ b/extensions/exposition/schemas/io/output.cos.yaml
@@ -1,0 +1,5 @@
+oneOf:
+  - type: boolean
+  - type: array
+    items:
+      type: string

--- a/extensions/exposition/source/HTTP/Server.ts
+++ b/extensions/exposition/source/HTTP/Server.ts
@@ -102,7 +102,7 @@ export class Server extends Connector {
         else
           status = 200
 
-      response.statusCode = status
+      response.statusCode = message.status = status
       write(context, response, message)
     }
   }
@@ -116,7 +116,7 @@ export class Server extends Connector {
         ? exception.status
         : 500
 
-      const message: OutgoingMessage = {}
+      const message: OutgoingMessage = { status: response.statusCode }
       const verbose = exception instanceof ClientError || this.properties.debug
 
       if (verbose)

--- a/extensions/exposition/source/directives/auth/Authorization.ts
+++ b/extensions/exposition/source/directives/auth/Authorization.ts
@@ -37,10 +37,10 @@ export class Authorization implements DirectiveFamily<Directive, Extension> {
   private bans: Component | null = null
 
   public create (name: string, value: any, remotes: Remotes): Directive {
-    assert.ok(name in CLASSES,
+    assert.ok(name in constructors,
       `Directive '${name}' is not provided by the '${this.name}' family.`)
 
-    const Class = CLASSES[name]
+    const Class = constructors[name]
 
     for (const name of REMOTES)
       this.discovery[name] ??= remotes.discover('identity', name)
@@ -132,7 +132,7 @@ export class Authorization implements DirectiveFamily<Directive, Extension> {
   }
 }
 
-const CLASSES: Record<string, new (value: any, argument?: any) => Directive> = {
+const constructors: Record<string, new (value: any, argument?: any) => Directive> = {
   anonymous: Anonymous,
   id: Id,
   role: Role,

--- a/extensions/exposition/source/directives/index.ts
+++ b/extensions/exposition/source/directives/index.ts
@@ -1,11 +1,12 @@
-import { dev } from './dev'
 import { authorization } from './auth'
 import { cache } from './cache'
-import { octets } from './octets'
 import { cors } from './cors'
+import { dev } from './dev'
+import { octets } from './octets'
+import { io } from './io'
 import { vary } from './vary'
 import type { DirectiveFamily } from '../RTD'
 import type { Interceptor } from '../Interception'
 
-export const families: DirectiveFamily[] = [authorization, cache, octets, vary, dev]
+export const families: DirectiveFamily[] = [authorization, io, cache, vary, octets, dev]
 export const interceptors: Interceptor[] = [cors]

--- a/extensions/exposition/source/directives/io/Directive.ts
+++ b/extensions/exposition/source/directives/io/Directive.ts
@@ -1,0 +1,11 @@
+import type { Input } from '../../io'
+
+export interface Directive {
+  attach: (context: Input) => void
+}
+
+export interface Constructor {
+  validate: (value: unknown) => void
+
+  new (value: any): Directive
+}

--- a/extensions/exposition/source/directives/io/IO.ts
+++ b/extensions/exposition/source/directives/io/IO.ts
@@ -1,4 +1,5 @@
 import { Output } from './Output'
+import { Input } from './Input'
 import type { Constructor, Directive } from './Directive'
 import type { Input as Context } from '../../io'
 import type { DirectiveFamily } from '../../RTD'
@@ -6,7 +7,6 @@ import type { DirectiveFamily } from '../../RTD'
 export class IO implements DirectiveFamily<Directive> {
   public readonly name = 'io'
   public readonly mandatory = true
-  private readonly denial: Output = new Output([])
 
   public create (name: string, value: unknown): Directive {
     if (!(name in constructors))
@@ -29,12 +29,15 @@ export class IO implements DirectiveFamily<Directive> {
     }
 
     if (!restricted)
-      this.denial.attach(context)
+      DENIAL.attach(context)
 
     return null
   }
 }
 
 const constructors: Record<string, Constructor> = {
-  output: Output
+  output: Output,
+  input: Input
 }
+
+const DENIAL: Output = new Output([])

--- a/extensions/exposition/source/directives/io/IO.ts
+++ b/extensions/exposition/source/directives/io/IO.ts
@@ -1,0 +1,40 @@
+import { Output } from './Output'
+import type { Constructor, Directive } from './Directive'
+import type { Input as Context } from '../../io'
+import type { DirectiveFamily } from '../../RTD'
+
+export class IO implements DirectiveFamily<Directive> {
+  public readonly name = 'io'
+  public readonly mandatory = true
+  private readonly denial: Output = new Output([])
+
+  public create (name: string, value: unknown): Directive {
+    if (!(name in constructors))
+      throw new Error(`Directive 'io:${name}' is not implemented.`)
+
+    const Directive = constructors[name]
+
+    Directive.validate(value)
+
+    return new Directive(value)
+  }
+
+  public preflight (directives: Directive[], context: Context): null {
+    let restricted = false
+
+    for (const directive of directives) {
+      restricted ||= directive instanceof Output
+
+      directive.attach(context)
+    }
+
+    if (!restricted)
+      this.denial.attach(context)
+
+    return null
+  }
+}
+
+const constructors: Record<string, Constructor> = {
+  output: Output
+}

--- a/extensions/exposition/source/directives/io/Input.ts
+++ b/extensions/exposition/source/directives/io/Input.ts
@@ -1,0 +1,50 @@
+import { BadRequest } from '../../HTTP'
+import * as schemas from './schemas'
+import type { Message } from './Message'
+import type { Directive } from './Directive'
+import type { Input as Context } from '../../io'
+
+export class Input implements Directive {
+  private readonly permissions: Permissions
+
+  public constructor (permissions: Permissions) {
+    this.permissions = permissions
+  }
+
+  public static validate (permissions: unknown): asserts permissions is Permissions {
+    schemas.input.validate(permissions, 'Incorrect \'io:input\' format')
+  }
+
+  public attach (context: Context): void {
+    context.pipelines.body.push((body) => this.check(body))
+  }
+
+  private check (body: unknown): unknown {
+    try {
+      schemas.message.validate(body)
+    } catch {
+      throw new BadRequest('Invalid request body.')
+    }
+
+    const property = this.violation(body)
+
+    if (property !== undefined)
+      throw new BadRequest(`Unexpected input: ${property}.`)
+
+    return body
+  }
+
+  private violation (value: Message | Message[]): string | undefined {
+    if (!Array.isArray(value))
+      return Object.keys(value).find((key) => !this.permissions.includes(key))
+
+    for (const item of value) {
+      const property = this.violation(item)
+
+      if (property !== undefined)
+        return property
+    }
+  }
+}
+
+export type Permissions = string[]

--- a/extensions/exposition/source/directives/io/Message.ts
+++ b/extensions/exposition/source/directives/io/Message.ts
@@ -1,0 +1,1 @@
+export type Message = Record<string, unknown>

--- a/extensions/exposition/source/directives/io/Output.ts
+++ b/extensions/exposition/source/directives/io/Output.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert'
+import type { Directive } from './Directive'
+import type { Input as Context } from '../../io'
+import type { OutgoingMessage } from '../../HTTP'
+
+export class Output implements Directive {
+  private readonly disabled: boolean = false
+  private readonly omitted: boolean = true
+  private readonly permissions: string[] = []
+
+  public constructor (permissions: Permissions) {
+    if (typeof permissions === 'boolean')
+      if (permissions)
+        this.disabled = true
+      else
+        this.omitted = false
+
+    else
+      this.permissions = permissions
+  }
+
+  public static validate (permissions: unknown): asserts permissions is Permissions {
+    assert.ok(typeof permissions === 'boolean' || Array.isArray(permissions),
+      'Incorrect \'io:output\' format: an array of property names or a boolean value is expected.')
+  }
+
+  public attach (context: Context): void {
+    context.pipelines.response.push(this.restrict(context))
+  }
+
+  private restrict (context: Context) {
+    return (message: OutgoingMessage) => {
+      if (this.disabled || message.body === undefined || message.body === null)
+        return
+
+      const acceptable = Object.getPrototypeOf(message.body) === PROTO ||
+        (Array.isArray(message.body) &&
+          message.body.every((entity) => Object.getPrototypeOf(entity) === PROTO))
+
+      if (!acceptable || this.permissions.length === 0) {
+        if (this.omitted)
+          console.warn(`Permissions for 'io:output' are not specified (${context.request.url}). ` +
+            'Response omitted.')
+
+        delete message.body
+
+        return
+      }
+
+      if (Array.isArray(message.body))
+        message.body = message.body.map((entity) => this.fit(entity as Entity))
+      else
+        message.body = this.fit(message.body as Entity)
+    }
+  }
+
+  private fit (entity: Entity): Entity {
+    const entries = Object.entries(entity)
+      .filter(([key]) => this.permissions.includes(key))
+
+    return Object.fromEntries(entries)
+  }
+}
+
+const PROTO = Object.getPrototypeOf({})
+
+type Entity = Record<string, unknown>
+
+export type Permissions = string[] | boolean

--- a/extensions/exposition/source/directives/io/index.ts
+++ b/extensions/exposition/source/directives/io/index.ts
@@ -1,0 +1,3 @@
+import { IO } from './IO'
+
+export const io = new IO()

--- a/extensions/exposition/source/directives/io/schemas.ts
+++ b/extensions/exposition/source/directives/io/schemas.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path'
+import schemas, { type Schema } from '@toa.io/schemas'
+import type { Permissions as InputPermissions } from './Input'
+import type { Permissions as OutputPermissions } from './Output'
+import type { Message } from './Message'
+
+const path = resolve(__dirname, '../../../schemas/io')
+const namespace = schemas.namespace(path)
+
+export const message: Schema<Message | Message[]> = namespace.schema('message')
+export const input: Schema<InputPermissions> = namespace.schema('input')
+export const output: Schema<OutputPermissions> = namespace.schema('output')

--- a/extensions/exposition/source/root.ts
+++ b/extensions/exposition/source/root.ts
@@ -25,6 +25,11 @@ const PREDEFINED: syntax.Node = {
                 family: 'auth',
                 name: 'echo',
                 value: null
+              },
+              {
+                family: 'io',
+                name: 'output',
+                value: ['id', 'roles']
               }
             ]
           }


### PR DESCRIPTION
[Documentation](https://github.com/toa-io/toa/blob/feat/exposition-io/extensions/exposition/documentation/io.md).

BREAKING CHANGE: responses are now empty unless permissions are specified.
BREAKING CHANGE: exposition of `identity.federation` is removed.