### PR TITLE
fix(agent): fix multiple captures

### DIFF
--- a/extensions/exposition/features/identity.federation.feature
+++ b/extensions/exposition/features/identity.federation.feature
@@ -40,7 +40,7 @@ Feature: Identity Federation
       200 OK
       id: ${{ User.id }}
       """
-    # ensuring identity idemptotency
+    # ensuring identity idempotency
     When the following request is received:
       """
       GET /identity/ HTTP/1.1
@@ -95,6 +95,7 @@ Feature: Identity Federation
         /:
           anonymous: true
           POST:
+            io:output: true
             incept: id
             endpoint: create
       """

--- a/libraries/agent/source/Agent.ts
+++ b/libraries/agent/source/Agent.ts
@@ -46,7 +46,7 @@ export class Agent {
 
       const match = this.captures.capture(this.response, line)
 
-      if (match === undefined)
+      if (match === null)
         throw new assert.AssertionError({
           message: `Response is missing '${line}'`,
           expected: line,

--- a/libraries/agent/source/Captures.test.ts
+++ b/libraries/agent/source/Captures.test.ts
@@ -23,3 +23,13 @@ it('should not capture parts of the words', async () => {
 
   expect(word).toBe(undefined)
 })
+
+it('should substitute multiple times', async () => {
+  captures.set('word', 'foo')
+
+  expect(() => captures.capture('hey foo foo', 'hey ${{ word }} ${{ word }}'))
+    .not.toThrow()
+
+  expect(() => captures.capture('hey foo bar', 'hey ${{ word }} ${{ word }}'))
+    .toThrow('Capture word already with different value: foo')
+})

--- a/libraries/agent/source/Captures.test.ts
+++ b/libraries/agent/source/Captures.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   captures = new Captures()
 })
 
-it('should capture parts values', async () => {
+it('should capture parts of the source', async () => {
   captures.capture('hello world', 'hello ${{ word }}')
 
   const word = captures.get('word')
@@ -27,9 +27,19 @@ it('should not capture parts of the words', async () => {
 it('should substitute multiple times', async () => {
   captures.set('word', 'foo')
 
-  expect(() => captures.capture('hey foo foo', 'hey ${{ word }} ${{ word }}'))
-    .not.toThrow()
+  expect(captures.capture('hey foo foo', 'hey ${{ word }} ${{ word }}'))
+    .toEqual([])
 
-  expect(() => captures.capture('hey foo bar', 'hey ${{ word }} ${{ word }}'))
-    .toThrow('Capture word already with different value: foo')
+  expect(captures.capture('hey foo bar', 'hey ${{ word }} ${{ word }}'))
+    .toBe(null)
+})
+
+it('should substitute parts of the words', async () => {
+  captures.set('host', 'domain.com')
+
+  expect(captures.capture('foo', 'https://${{ host }}/path'))
+    .toBe(null)
+
+  expect(captures.capture('https://domain.com/path', 'https://${{ host }}/path'))
+    .toEqual([])
 })

--- a/libraries/agent/source/Captures.ts
+++ b/libraries/agent/source/Captures.ts
@@ -27,8 +27,10 @@ export class Captures extends Map<string, string> {
    * or array of captured keys (can be empty)
    */
   public capture (source: string, matcher: string): readonly string[] | undefined {
+    let i = 0
+
     const expression = PADDING + regexpEscape(matcher).replaceAll(CAPTURE,
-      (_, name: string) => `(?<${Buffer.from(name).toString('base64url')}>\\S{1,2048})`)
+      (_, name: string) => `(?<${Buffer.from(name + '.' + i++).toString('base64url')}>\\S{1,2048})`)
 
     const rx = new RegExp(expression, 'i')
     const match = source.match(rx)
@@ -36,7 +38,7 @@ export class Captures extends Map<string, string> {
     if (match === null) return undefined
 
     return Object.entries(match.groups ?? {}).map(([key, value]) => {
-      const name = regexpUnescape(Buffer.from(key, 'base64url').toString())
+      const [name] = regexpUnescape(Buffer.from(key, 'base64url').toString()).split('.')
 
       this.set(name, value)
 

--- a/libraries/agent/source/Captures.ts
+++ b/libraries/agent/source/Captures.ts
@@ -27,7 +27,7 @@ export class Captures extends Map<string, string> {
     matcher = this.substitute(matcher)
 
     const expression = PADDING + regexpEscape(matcher).replaceAll(CAPTURE,
-      (_, name: string) => `(?<${Buffer.from(name + '.' + i++).toString('base64url')}>\\S{1,2048})`)
+      (_, name: string) => `(?<${Buffer.from(name + '#' + i++).toString('base64url')}>\\S{1,2048})`)
 
     const rx = new RegExp(expression, 'i')
     const match = source.match(rx)
@@ -35,7 +35,8 @@ export class Captures extends Map<string, string> {
     if (match === null) return null
 
     return Object.entries(match.groups ?? {}).map(([key, value]) => {
-      const [name] = regexpUnescape(Buffer.from(key, 'base64url').toString()).split('.')
+      const parts = regexpUnescape(Buffer.from(key, 'base64url').toString()).split('#')
+      const name = parts.slice(0, -1).join('#')
 
       this.set(name, value)
 


### PR DESCRIPTION
`foo ${{ bar }} ${{ bar }}` should be transformed into a valid expression.