### PR TITLE
refactor(exposition): add `private` cache-control response to authenticated requests 

### DIFF
--- a/extensions/exposition/features/cache.feature
+++ b/extensions/exposition/features/cache.feature
@@ -11,6 +11,40 @@ Feature: Caching
       | _id                              | identity                         | role      |
       | 775a648d054e4ce1a65f8f17e5b51803 | b70a7dbca6b14a2eaac8a9eb4b2ff4db | developer |
 
+  Scenario: Default caching
+    Given the annotation:
+      """yaml
+      /:
+        anonymous: true
+        GET:
+          dev:stub: foo
+        /private:
+          auth:role: developer
+          GET:
+            dev:stub: bar
+      """
+    When the following request is received:
+      """
+      GET / HTTP/1.1
+      host: nex.toa.io
+      """
+    Then the reply does not contain:
+      """
+      cache-control:
+      """
+    When the following request is received:
+      """
+      GET /private/ HTTP/1.1
+      host: nex.toa.io
+      authorization: Basic ZGV2ZWxvcGVyOnNlY3JldA==
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+
+      cache-control: private
+      """
+
   Scenario: Caching successful response
     Given the annotation:
       """yaml
@@ -65,7 +99,7 @@ Feature: Caching
       """
       200 OK
       authorization: Token ${{ token }}
-      cache-control: no-store
+      cache-control: private
       """
     When the following request is received:
       """
@@ -156,7 +190,7 @@ Feature: Caching
       """
       200 OK
       authorization: Token ${{ token }}
-      cache-control: no-store
+      cache-control: private
       """
     When the following request is received:
       """
@@ -213,12 +247,11 @@ Feature: Caching
       host: nex.toa.io
       authorization: Basic ZGV2ZWxvcGVyOnNlY3JldA==
       """
-    # `no-store` when token is issued
     Then the following reply is sent:
       """
       200 OK
       authorization: Token ${{ token }}
-      cache-control: no-store
+      cache-control: private
       """
     When the following request is received:
       """

--- a/extensions/exposition/features/cors.feature
+++ b/extensions/exposition/features/cors.feature
@@ -1,3 +1,4 @@
+@security
 Feature: CORS Support
 
   Scenario: Using CORS

--- a/extensions/exposition/features/identity.tokens.feature
+++ b/extensions/exposition/features/identity.tokens.feature
@@ -70,7 +70,6 @@ Feature: Tokens lifecycle
       """
       200 OK
       authorization: Token
-      cache-control: no-store
 
       Hello
       """
@@ -170,60 +169,4 @@ Feature: Tokens lifecycle
     Then the following reply is sent:
       """
       403 Forbidden
-      """
-
-  Scenario: Responses with tokens comes with `no-store`
-    Given the `identity.tokens` configuration:
-      """yaml
-      refresh: 1
-      """
-    And the annotation:
-      """yaml
-      /:
-        io:output: true
-        /hello/:id:
-          auth:id: id
-          GET:
-            dev:stub: Hello
-        /cacheable/:id:
-          auth:id: id
-          cache:control: max-age=10000
-          GET:
-            dev:stub: Keep it
-      """
-    When the following request is received:
-      """
-      GET /hello/efe3a65ebbee47ed95a73edd911ea328/ HTTP/1.1
-      host: nex.toa.io
-      authorization: Basic ZGV2ZWxvcGVyOnNlY3JldA==
-      """
-    Then the following reply is sent:
-      """
-      200 OK
-      authorization: Token ${{ token }}
-      cache-control: no-store
-      """
-    Then after 1 second
-    When the following request is received:
-      """
-      GET /cacheable/efe3a65ebbee47ed95a73edd911ea328/ HTTP/1.1
-      host: nex.toa.io
-      authorization: Token ${{ token }}
-      """
-    Then the following reply is sent:
-      """
-      200 OK
-      authorization: Token ${{ fresh_token }}
-      cache-control: no-store
-      """
-    When the following request is received:
-      """
-      GET /cacheable/efe3a65ebbee47ed95a73edd911ea328/ HTTP/1.1
-      host: nex.toa.io
-      authorization: Token ${{ fresh_token }}
-      """
-    Then the following reply is sent:
-      """
-      200 OK
-      cache-control: private, max-age=10000
       """

--- a/extensions/exposition/source/directives/auth/Authorization.ts
+++ b/extensions/exposition/source/directives/auth/Authorization.ts
@@ -109,7 +109,6 @@ export class Authorization implements DirectiveFamily<Directive, Extension> {
 
     response.headers ??= new Headers()
     response.headers.set('authorization', authorization)
-    response.headers.append('cache-control', 'no-store')
   }
 
   private async resolve (authority: string, authorization: string | undefined): Promise<Identity | null> {


### PR DESCRIPTION
Prevents AWS CloudFront from caching responses to authenticated requests.