### PR TITLE
fix: headerless multipart boundary must start with empty line

### DIFF
--- a/extensions/exposition/source/HTTP/messages.ts
+++ b/extensions/exposition/source/HTTP/messages.ts
@@ -72,7 +72,7 @@ function stream
   })
 }
 
-function multipart
+export function multipart
 (message: OutgoingMessage, context: Context, response: http.ServerResponse): void {
   if (context.encoder === null)
     throw new NotAcceptable()
@@ -82,7 +82,11 @@ function multipart
   response.setHeader('content-type', `${encoder.multipart}; boundary=${BOUNDARY}`)
 
   message.body
-    .map((part: unknown) => Buffer.concat([CUT, encoder.encode(part), CRLF]))
+    .map((part: unknown) => Buffer.concat([
+      CUT,
+      CRLF /* indicates no boundary headers */,
+      encoder.encode(part),
+      CRLF]))
     .on('end', () => response.end(FINALCUT))
     .pipe(response)
 }


### PR DESCRIPTION
According to [multipart format documentation](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html):  To begin with, NO header fields are actually required in body parts. **A body part that starts with a blank line**, therefore, is allowed and is a body part for which all default values are to be assumed (_emphasis is mine_)

That means that in case when we don't provide any boundary headers (as Toa is doing) we should add a blank line before the actual body. This PR proposes a fix and regression test for that.