### PR TITLE
refactor(exposition): add streaming workflows

### DIFF
--- a/extensions/exposition/documentation/octets.md
+++ b/extensions/exposition/documentation/octets.md
@@ -222,8 +222,8 @@ A workflow is a list of endpoints to be called.
 The following input will be passed to each endpoint:
 
 ```yaml
-storage: string
 authority: string
+storage: string
 path: string
 entry: Entry
 parameters: Record<string, string> # route parameters

--- a/extensions/exposition/documentation/octets.md
+++ b/extensions/exposition/documentation/octets.md
@@ -96,10 +96,12 @@ content-type: multipart/yaml; boundary=cut
 id: eecd837c
 type: image/jpeg
 created: 1698004822358
+
 --cut
 
 step: optimize
 status: completed
+
 --cut
 
 step: resize
@@ -107,11 +109,12 @@ error:
   code: TOO_SMALL
   message: Image is too small
 status: completed
+
 --cut
 
 step: analyze
-exception: SyntaxError: Invalid or unexpected token
 status: exception
+
 --cut--
 ```
 

--- a/extensions/exposition/documentation/octets.md
+++ b/extensions/exposition/documentation/octets.md
@@ -20,7 +20,7 @@ Stores the content of the request body into a storage, under the request path wi
 specified `content-type`.
 
 If request's `content-type` is not acceptable, or if the request body does not pass
-the [validation](/extensions/storages/readme.md#async-putpath-string-stream-readable-type-typecontrol-maybeentry),
+the [validation](/extensions/storages/readme.md#async-putpath-string-stream-readable-options-options-maybeentry),
 the request is rejected with a `415 Unsupported Media Type` response.
 
 The value of the directive is `null` or an object with the following properties:
@@ -83,7 +83,8 @@ is [multipart](protocol.md#multipart-types).
 The first part represents the created Entry, which is sent immediately after the BLOB is stored,
 while subsequent parts are results from the workflow endpoints, sent as soon as they are available.
 
-In case a workflow endpoint returns an `Error`, the error part is sent, and the response is closed.
+In case a workflow endpoint returns an `Error`, the error part is sent,
+and the response is closed.
 Error's properties are added to the error part, among with the `step` identifier.
 
 ```
@@ -91,16 +92,26 @@ Error's properties are added to the error part, among with the `step` identifier
 content-type: multipart/yaml; boundary=cut
 
 --cut
+
 id: eecd837c
 type: image/jpeg
 created: 1698004822358
 --cut
-optimize: null
+
+step: optimize
+status: completed
 --cut
+
+step: resize
 error:
-  step: resize
   code: TOO_SMALL
   message: Image is too small
+status: completed
+--cut
+
+step: analyze
+exception: SyntaxError: Invalid or unexpected token
+status: exception
 --cut--
 ```
 
@@ -193,22 +204,6 @@ the entry is deleted.
 
 The error returned by the workflow prevents the deletion of the entry.
 
-## `octets:permute`
-
-Performs
-a [permutation](/extensions/storages/readme.md#async-permutepath-string-ids-string-maybevoid) on the
-entries
-under the request path.
-
-```yaml
-/images:
-  octets:context: images
-  PUT:
-    octets:permute: ~
-```
-
-The request body must be a list of entry identifiers.
-
 ## `octets:workflow`
 
 Execute a [workflow](#workflows) on the entry under the request path.
@@ -228,13 +223,15 @@ The following input will be passed to each endpoint:
 
 ```yaml
 storage: string
+authority: string
 path: string
 entry: Entry
 parameters: Record<string, string> # route parameters
 ```
 
-See [Entry](/extensions/storages/readme.md#entry) and an
-example [workflow step processor](../features/steps/components/octets.tester).
+- [Storages](/extensions/storages/readme.md)
+- [Authorities](authorities.md)
+- Example [workflow step processor](../features/steps/components/octets.tester)
 
 A _workflow unit_ is an object with keys referencing the workflow step identifier, and an endpoint
 as value.
@@ -258,4 +255,5 @@ octets:store:
       analyze: images.analyze     # executed in parallel with `resize`
 ```
 
-If one of the workflow units returns an error, the execution of the workflow is interrupted.
+If one of the workflow units returns or throws an error,
+the execution of the workflow is interrupted.

--- a/extensions/exposition/features/octets.entries.feature
+++ b/extensions/exposition/features/octets.entries.feature
@@ -123,7 +123,6 @@ Feature: Accessing entries
       """
       200 OK
       content-type: application/yaml
-      content-length: 124
 
       id: 10cf16b458f759e0d617f2f3d83599ff
       type: application/octet-stream

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -323,3 +323,94 @@ Feature: Octets storage workflows
       output: 10cf16b458f759e0d617f2f3d83599ff
       --cut--
       """
+
+  Scenario: Workflow with streaming response
+    Given the `octets.tester` is running
+    And the annotation:
+      """yaml
+      /:
+        auth:anonymous: true
+        octets:context: octets
+        POST:
+          octets:store:
+            workflow:
+              - foo: octets.tester.foo
+              - yield: octets.tester.yield
+      """
+    When the stream of `lenna.ascii` is received with the following headers:
+      """
+      POST / HTTP/1.1
+      host: nex.toa.io
+      accept: application/yaml
+      content-type: application/octet-stream
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+      content-type: multipart/yaml; boundary=cut
+
+      --cut
+
+      id: 10cf16b458f759e0d617f2f3d83599ff
+      type: application/octet-stream
+      --cut
+
+      step: foo
+      status: completed
+      --cut
+
+      step: yield
+      output: hello
+      --cut
+
+      step: yield
+      output: world
+      --cut
+
+      step: yield
+      status: completed
+      --cut--
+      """
+
+  Scenario: Workflow with streaming response and an exception
+    Given the `octets.tester` is running
+    And the annotation:
+      """yaml
+      /:
+        auth:anonymous: true
+        octets:context: octets
+        POST:
+          octets:store:
+            workflow:
+              yield: octets.tester.yex
+      """
+    When the stream of `lenna.ascii` is received with the following headers:
+      """
+      POST / HTTP/1.1
+      host: nex.toa.io
+      accept: application/yaml
+      content-type: application/octet-stream
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+      content-type: multipart/yaml; boundary=cut
+
+      --cut
+
+      id: 10cf16b458f759e0d617f2f3d83599ff
+      type: application/octet-stream
+      --cut
+
+      step: yield
+      output: hello
+      --cut
+
+      step: yield
+      output: world
+      --cut
+
+      step: yield
+      status: exception
+      --cut--
+      """

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -356,9 +356,11 @@ Feature: Octets storage workflows
       content-type: multipart/yaml; boundary=cut
 
       --cut
+
       step: echo
       status: completed
       output: 10cf16b458f759e0d617f2f3d83599ff
+
       --cut--
       """
 

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -24,7 +24,7 @@ Feature: Octets storage workflows
       """
       POST / HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       content-type: application/octet-stream
       """
     Then the following reply is sent:
@@ -107,7 +107,7 @@ Feature: Octets storage workflows
       """
       POST / HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       content-type: application/octet-stream
       """
     Then the following reply is sent:
@@ -164,7 +164,7 @@ Feature: Octets storage workflows
       """
       DELETE /10cf16b458f759e0d617f2f3d83599ff HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       """
     Then the following reply is sent:
       """
@@ -218,7 +218,7 @@ Feature: Octets storage workflows
       """
       DELETE /10cf16b458f759e0d617f2f3d83599ff HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       """
     Then the following reply is sent:
       """
@@ -261,7 +261,7 @@ Feature: Octets storage workflows
       """
       POST /hello/world/ HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       content-type: application/octet-stream
       """
     Then the following reply is sent:
@@ -299,7 +299,7 @@ Feature: Octets storage workflows
       """
       POST /hello/world/ HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       content-type: application/octet-stream
       """
     Then the following reply is sent:
@@ -348,7 +348,7 @@ Feature: Octets storage workflows
       """
       DELETE /10cf16b458f759e0d617f2f3d83599ff HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       """
     Then the following reply is sent:
       """
@@ -381,7 +381,7 @@ Feature: Octets storage workflows
       """
       POST / HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       content-type: application/octet-stream
       """
     Then the following reply is sent:
@@ -393,22 +393,27 @@ Feature: Octets storage workflows
 
       id: 10cf16b458f759e0d617f2f3d83599ff
       type: application/octet-stream
+
       --cut
 
       step: foo
       status: completed
+
       --cut
 
       step: yield
       output: hello
+
       --cut
 
       step: yield
       output: world
+
       --cut
 
       step: yield
       status: completed
+
       --cut--
       """
 
@@ -428,7 +433,7 @@ Feature: Octets storage workflows
       """
       POST / HTTP/1.1
       host: nex.toa.io
-      accept: application/yaml
+      accept: application/yaml, multipart/yaml
       content-type: application/octet-stream
       """
     Then the following reply is sent:
@@ -440,17 +445,21 @@ Feature: Octets storage workflows
 
       id: 10cf16b458f759e0d617f2f3d83599ff
       type: application/octet-stream
+
       --cut
 
       step: yield
       output: hello
+
       --cut
 
       step: yield
       output: world
+
       --cut
 
       step: yield
       status: exception
+
       --cut--
       """

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -33,18 +33,29 @@ Feature: Octets storage workflows
       content-type: multipart/yaml; boundary=cut
 
       --cut
+
       id: 10cf16b458f759e0d617f2f3d83599ff
       type: application/octet-stream
       size: 8169
       --cut
-      add-foo: null
+
+      step: add-foo
+      status: completed
       --cut
-      add-bar:
+
+      step: add-bar
+      output:
         bar: baz
+      status: completed
       --cut
-      add-baz: null
+
+      step: add-baz
+      status: completed
       --cut
-      diversify: null
+
+      step: diversify
+      output: hello
+      status: completed
       --cut--
       """
     When the following request is received:
@@ -88,9 +99,9 @@ Feature: Octets storage workflows
         POST:
           octets:store:
             workflow:
-              add-foo: octets.tester.foo
-              add-bar: octets.tester.err
-              add-baz: octets.tester.baz
+              - add-foo: octets.tester.foo
+              - add-bar: octets.tester.err
+              - add-baz: octets.tester.baz
       """
     When the stream of `lenna.ascii` is received with the following headers:
       """
@@ -109,12 +120,16 @@ Feature: Octets storage workflows
       type: application/octet-stream
       size: 8169
       --cut
-      add-foo: null
+
+      step: add-foo
+      status: completed
       --cut
+
+      step: add-bar
       error:
-        step: add-bar
         code: ERROR
         message: Something went wrong
+      status: completed
       --cut--
       """
 
@@ -157,7 +172,9 @@ Feature: Octets storage workflows
       content-type: multipart/yaml; boundary=cut
 
       --cut
-      echo: 10cf16b458f759e0d617f2f3d83599ff
+      step: echo
+      status: completed
+      output: 10cf16b458f759e0d617f2f3d83599ff
       --cut--
       """
     When the following request is received:
@@ -209,8 +226,10 @@ Feature: Octets storage workflows
       content-type: multipart/yaml; boundary=cut
 
       --cut
+
+      step: err
+      status: completed
       error:
-        step: err
         code: ERROR
         message: Something went wrong
       --cut--
@@ -251,11 +270,15 @@ Feature: Octets storage workflows
       content-type: multipart/yaml; boundary=cut
 
       --cut
+
       id: 10cf16b458f759e0d617f2f3d83599ff
       type: application/octet-stream
       size: 8169
       --cut
-      concat: hello world
+
+      step: concat
+      status: completed
+      output: hello world
       --cut--
       """
 
@@ -295,6 +318,8 @@ Feature: Octets storage workflows
       content-type: multipart/yaml; boundary=cut
 
       --cut
-      echo: 10cf16b458f759e0d617f2f3d83599ff
+      step: echo
+      status: completed
+      output: 10cf16b458f759e0d617f2f3d83599ff
       --cut--
       """

--- a/extensions/exposition/features/octets.workflows.feature
+++ b/extensions/exposition/features/octets.workflows.feature
@@ -282,6 +282,44 @@ Feature: Octets storage workflows
       --cut--
       """
 
+  Scenario: Passing authority to the workflow
+    Given the `octets.tester` is running
+    And the annotation:
+      """yaml
+      /:
+        /:a/:b:
+          auth:anonymous: true
+          octets:context: octets
+          POST:
+            octets:store:
+              workflow:
+                authority: octets.tester.authority
+      """
+    When the stream of `lenna.ascii` is received with the following headers:
+      """
+      POST /hello/world/ HTTP/1.1
+      host: nex.toa.io
+      accept: application/yaml
+      content-type: application/octet-stream
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+      content-type: multipart/yaml; boundary=cut
+
+      --cut
+
+      id: 10cf16b458f759e0d617f2f3d83599ff
+      type: application/octet-stream
+      size: 8169
+      --cut
+
+      step: authority
+      status: completed
+      output: nex
+      --cut--
+      """
+
   Scenario: Executing a workflow with `octets:workflow`
     Given the `octets.tester` is running
     And the annotation:

--- a/extensions/exposition/features/steps/components/octets.tester/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/octets.tester/manifest.toa.yaml
@@ -7,9 +7,10 @@ storages: octets
 operations:
   foo: &operation
     input:
+      authority*: string
       storage*: string
       path*: string
-      entry: object
+      entry*: object
       parameters: object
   bar: *operation
   baz: *operation
@@ -19,3 +20,4 @@ operations:
   diversify: *operation
   yield: *operation
   yex: *operation
+  authority: *operation

--- a/extensions/exposition/features/steps/components/octets.tester/manifest.toa.yaml
+++ b/extensions/exposition/features/steps/components/octets.tester/manifest.toa.yaml
@@ -17,3 +17,5 @@ operations:
   echo: *operation
   concat: *operation
   diversify: *operation
+  yield: *operation
+  yex: *operation

--- a/extensions/exposition/features/steps/components/octets.tester/operations/authority.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/authority.js
@@ -1,0 +1,7 @@
+'use strict'
+
+function computation (input) {
+  return input.authority
+}
+
+exports.computation = computation

--- a/extensions/exposition/features/steps/components/octets.tester/operations/baz.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/baz.js
@@ -4,8 +4,7 @@ import { setTimeout } from 'node:timers/promises'
 
 async function baz (input, context) {
   await setTimeout(30)
-
-  return context.storages.octets.annotate(input.path, 'baz', 'qux')
+  await context.storages.octets.annotate(input.path, 'baz', 'qux')
 }
 
 exports.effect = baz

--- a/extensions/exposition/features/steps/components/octets.tester/operations/diversify.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/diversify.js
@@ -8,7 +8,9 @@ const lenna = join(__dirname, 'lenna.png')
 async function diversify (input, context) {
   const stream = createReadStream(lenna)
 
-  return context.storages[input.storage].diversify(input.path, 'hello.png', stream)
+  await context.storages[input.storage].diversify(input.path, 'hello.png', stream)
+
+  return 'hello'
 }
 
 exports.effect = diversify

--- a/extensions/exposition/features/steps/components/octets.tester/operations/foo.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/foo.js
@@ -1,7 +1,7 @@
 'use strict'
 
-function foo (input, context) {
-  return context.storages.octets.annotate(input.path, 'foo', 'bar')
+async function foo (input, context) {
+  await context.storages.octets.annotate(input.path, 'foo', 'bar')
 }
 
 exports.effect = foo

--- a/extensions/exposition/features/steps/components/octets.tester/operations/yex.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/yex.js
@@ -1,0 +1,16 @@
+'use strict'
+
+import { setTimeout } from 'node:timers/promises'
+
+async function * effect (_) {
+  await setTimeout(10)
+  yield 'hello'
+
+  await setTimeout(10)
+  yield 'world'
+
+  await setTimeout(10)
+  throw new Error('Oops!')
+}
+
+exports.effect = effect

--- a/extensions/exposition/features/steps/components/octets.tester/operations/yield.js
+++ b/extensions/exposition/features/steps/components/octets.tester/operations/yield.js
@@ -1,0 +1,13 @@
+'use strict'
+
+import { setTimeout } from 'node:timers/promises'
+
+async function * effect (_) {
+  await setTimeout(10)
+  yield 'hello'
+
+  await setTimeout(10)
+  yield 'world'
+}
+
+exports.effect = effect

--- a/extensions/exposition/source/HTTP/messages.test.ts
+++ b/extensions/exposition/source/HTTP/messages.test.ts
@@ -5,6 +5,7 @@ import { generate } from 'randomstring'
 import * as msgpack from 'msgpackr'
 import { multipart, read, type OutgoingMessage } from './messages'
 import { BadRequest, UnsupportedMediaType } from './exceptions'
+import { formats } from './formats'
 import { Timing } from './Timing'
 import type * as http from 'node:http'
 import type { Context } from './Context'
@@ -84,7 +85,7 @@ describe('read', () => {
       }
     }()
 
-    const context = { encoder: new TextEncoder() } as unknown as Context
+    const context = { encoder: formats['text/plain'] } as unknown as Context
     const message = { body: Readable.from(['Hello', 'New', 'World']) } as unknown as OutgoingMessage
 
     multipart(message, context, response as unknown as http.ServerResponse)

--- a/extensions/exposition/source/HTTP/messages.ts
+++ b/extensions/exposition/source/HTTP/messages.ts
@@ -85,7 +85,8 @@ export function multipart
     .map((part: unknown) => Buffer.concat([
       CUT,
       CRLF /* indicates no boundary headers */,
-      encoder.encode(part)]))
+      encoder.encode(part),
+      CRLF]))
     .on('end', () => response.end(FINALCUT))
     .pipe(response)
 }

--- a/extensions/exposition/source/HTTP/messages.ts
+++ b/extensions/exposition/source/HTTP/messages.ts
@@ -85,8 +85,7 @@ export function multipart
     .map((part: unknown) => Buffer.concat([
       CUT,
       CRLF /* indicates no boundary headers */,
-      encoder.encode(part),
-      CRLF]))
+      encoder.encode(part)]))
     .on('end', () => response.end(FINALCUT))
     .pipe(response)
 }

--- a/extensions/exposition/source/directives/octets/workflows/Execution.ts
+++ b/extensions/exposition/source/directives/octets/workflows/Execution.ts
@@ -105,6 +105,7 @@ export class Execution extends Readable {
 }
 
 export interface Context {
+  authority: string
   storage: string
   path: string
   entry: Entry

--- a/extensions/exposition/source/directives/octets/workflows/Workflow.ts
+++ b/extensions/exposition/source/directives/octets/workflows/Workflow.ts
@@ -23,12 +23,13 @@ export class Workflow {
   public execute
   (input: Input, storage: string, entry: Entry, params: Parameter[]): Execution {
     const path = posix.join(input.request.url, entry.id)
+    const authority = input.authority
     const parameters: Record<string, string> = {}
 
     for (const { name, value } of params)
       parameters[name] = value
 
-    const context: Context = { storage, path, entry, parameters }
+    const context: Context = { authority, storage, path, entry, parameters }
 
     return new Execution(context, this.units, this.remotes)
   }


### PR DESCRIPTION
- change workflow output format to something that should be easier to process
- add support for workflow steps that stream response


Example output:

```
200 OK
content-type: multipart/yaml; boundary=cut

--cut

step: crop
output: 300x300.jpeg

--cut

step: crop
output: 60x60.jpeg

--cut

step: crop
status: completed

--cut--
```