### PR TITLE
fix: allow token aud to be array of strings

### DIFF
--- a/extensions/exposition/components/identity.federation/source/types/context.ts
+++ b/extensions/exposition/components/identity.federation/source/types/context.ts
@@ -48,7 +48,7 @@ export interface JwtHeader {
 export interface IdToken {
   iss: string
   sub: string
-  aud: string
+  aud: string | string[]
   exp: number
   iat: number
   nbf?: number


### PR DESCRIPTION
As per [documentation](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation):

_`aud`: REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain identifiers for other audiences. In the general case, the aud value is an array of case-sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case-sensitive string._ 

However our current code accepts only single string `aud`. This PR fixes that and adds a unit test for `aud` verification.