### PR TITLE
fix(generic): strip trailing spaces when dedenting

### DIFF
--- a/libraries/agent/source/Agent.test.ts
+++ b/libraries/agent/source/Agent.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-template-curly-in-string */
+/// <reference types="jest" />
+
+import { Agent } from './Agent'
+
+let agent: Agent
+
+beforeEach(() => {
+  agent = new Agent()
+})
+
+it('should match lines in order with headers in between', () => {
+  agent.response = '201 Created\n' +
+    'server: Exposition/1.0.0\n' +
+    'authorization: Token v3.local.eziy\n' +
+    '\n' +
+    'id: abc-123'
+
+  const expected = '\n' +
+    '      201 Created\n' +
+    '      authorization: Token ${{ identity.token }} \n' +
+    '\n' +
+    '      id: ${{ identity.id }}\n' +
+    '    '
+
+  expect(() => agent.responseIncludes(expected)).not.toThrow()
+
+  expect(agent.captures.get('identity.token')).toBe('v3.local.eziy')
+  expect(agent.captures.get('identity.id')).toBe('abc-123')
+})
+
+it('should not match lines out of order', () => {
+  agent.response = 'line 1\nline 2'
+
+  expect(() => agent.responseIncludes('line 2\nline 1')).toThrow(/missing 'line 1'/)
+})

--- a/libraries/generic/source/trim.js
+++ b/libraries/generic/source/trim.js
@@ -1,7 +1,8 @@
 'use strict'
 
 /**
- * Removes leading/trailing blank lines and dedents by the first line's padding.
+ * Removes leading/trailing blank lines, dedents by the first line's padding,
+ * and strips trailing whitespace from each line.
  *
  * @param {string} input
  * @return {string}
@@ -21,11 +22,13 @@ function trim (input) {
   const match = lines[0].match(/^\s*/)
   const padding = match === null ? '' : match[0]
 
-  if (padding === '')
-    return lines.join('\n')
-
   return lines
-    .map((line) => line.startsWith(padding) ? line.slice(padding.length) : line)
+    .map((line) => {
+      if (padding !== '' && line.startsWith(padding))
+        line = line.slice(padding.length)
+
+      return line.trimEnd()
+    })
     .join('\n')
 }
 

--- a/libraries/generic/source/trim.test.js
+++ b/libraries/generic/source/trim.test.js
@@ -35,3 +35,9 @@ it('should trim tabs by first line padding', async () => {
 
   expect(trimmed).toStrictEqual('line one\nline two\n\tindented')
 })
+
+it('should trim trailing spaces', async () => {
+  const trimmed = trim('  line one \n  line two  ')
+
+  expect(trimmed).toStrictEqual('line one\nline two')
+})


### PR DESCRIPTION
## Summary
- Strip trailing whitespace from each line in `trim` after first-line dedent, so indented feature samples with accidental trailing spaces still match.
- Add agent response-matching coverage for ordered lines with headers in between and trailing spaces on capture lines.

## Test plan
- [x] `jest libraries/generic/source/trim.test.js libraries/agent/source/Agent.test.ts`
- [ ] Confirm feature steps that assert `authorization: Token ${{ ... }} ` (trailing space) pass again


Made with [Cursor](https://cursor.com)