### PR TITLE
feat(realtime): add properties exposition permissions

### DIFF
--- a/extensions/realtime/features/static.feature
+++ b/extensions/realtime/features/static.feature
@@ -38,6 +38,37 @@ Feature: Static routes
         text: Hello!
       """
 
+  Scenario: Exposing event properties
+    Given the `messages` component is running with routes:
+      """yaml
+      created:
+        key: [sender, recipient]
+        expose: [text, sender]
+      """
+    And the stream `004e02a959c04cecaf111827f91caa36` is consumed
+    And the stream `96db5a47a8244eb3b21820781b7d596e` is consumed
+    When the `messages.create` is called with:
+      """yaml
+      input:
+        sender: 96db5a47a8244eb3b21820781b7d596e
+        recipient: 004e02a959c04cecaf111827f91caa36
+        text: Hello!
+      """
+    Then an event is received from the stream `004e02a959c04cecaf111827f91caa36`:
+      """yaml
+      event: default.messages.created
+      data:
+        sender: 96db5a47a8244eb3b21820781b7d596e
+        text: Hello!
+      """
+    And an event is received from the stream `96db5a47a8244eb3b21820781b7d596e`:
+      """yaml
+      event: default.messages.created
+      data:
+        sender: 96db5a47a8244eb3b21820781b7d596e
+        text: Hello!
+      """
+
   Scenario: Routing an event using array
     Given the `messages` component is running with routes:
       """yaml

--- a/extensions/realtime/features/steps/Components.ts
+++ b/extensions/realtime/features/steps/Components.ts
@@ -5,6 +5,7 @@ import { parse } from '@toa.io/yaml'
 import * as stage from '@toa.io/userland/stage'
 import { type Component, type Request } from '@toa.io/core'
 import { timeout } from '@toa.io/generic'
+import { parse as parseRoutes, type Declaration } from '../../source/extension'
 import { Realtime } from './Realtime'
 
 @binding([Realtime])
@@ -18,14 +19,14 @@ export class Components {
 
   @given('the `{word}` component is running with routes:')
   public async run (component: string, yaml: string): Promise<void> {
-    const routes = parse<Manifest>(yaml)
+    const declaration = parse<Declaration>(yaml)
     const [name, namespace = 'default'] = component.split('.').reverse()
+    const routes = parseRoutes(declaration)
 
-    for (const [event, value] of Object.entries(routes)) {
-      const label = `${namespace}.${name}.${event}`
-      const properties = Array.isArray(value) ? value : [value]
+    for (const route of routes) {
+      const label = `${namespace}.${name}.${route.event}`
 
-      this.realtime.declare(label, properties)
+      this.realtime.declare(label, route.properties, route.expose)
     }
   }
 
@@ -65,7 +66,3 @@ function componentPaths (): string[] {
 }
 
 const ROOT = resolve(__dirname, 'components')
-
-interface Manifest {
-  realtime: Map<string, string | string[]>
-}

--- a/extensions/realtime/features/steps/Realtime.ts
+++ b/extensions/realtime/features/steps/Realtime.ts
@@ -3,6 +3,7 @@ import { encode } from '@toa.io/generic'
 import { type Connector } from '@toa.io/core'
 import { after, binding } from 'cucumber-tsflow'
 import { Factory } from '../../source'
+import type { Route } from '../../source/extension'
 
 @binding()
 export class Realtime {
@@ -21,8 +22,8 @@ export class Realtime {
     await this.service.disconnect()
   }
 
-  public declare (event: string, properties: string[]): void {
-    this.routes.push({ event, properties })
+  public declare (event: string, properties: string[], expose?: string[]): void {
+    this.routes.push({ event, properties, expose })
   }
 
   public async serve (): Promise<void> {
@@ -35,9 +36,4 @@ export class Realtime {
 
     await this.service.connect()
   }
-}
-
-interface Route {
-  event: string
-  properties: string[]
 }

--- a/extensions/realtime/source/Receiver.ts
+++ b/extensions/realtime/source/Receiver.ts
@@ -5,17 +5,21 @@ import type { Readable } from 'node:stream'
 export class Receiver extends Connector {
   private readonly event: string
   private readonly properties: string[]
+  private readonly expose?: string[]
   private readonly stream: Readable
 
-  public constructor (event: string, properties: string[], stream: Readable) {
+  public constructor (event: string, properties: string[], stream: Readable, expose?: string[]) {
     super()
 
     this.event = event
     this.properties = properties
+    this.expose = expose
     this.stream = stream
   }
 
   public receive (message: Message<Record<string, string>>): void {
+    const data = this.fit(message.payload)
+
     for (const property of this.properties) {
       const key = message.payload[property]
 
@@ -29,10 +33,20 @@ export class Receiver extends Connector {
       if (Array.isArray(key))
         // eslint-disable-next-line max-depth
         for (const k of key as string[])
-          this.push(k, message.payload)
+          this.push(k, data)
       else
-        this.push(key, message.payload)
+        this.push(key, data)
     }
+  }
+
+  private fit (payload: Record<string, string>): Record<string, string> {
+    if (this.expose === undefined)
+      return payload
+
+    const entries = Object.entries(payload)
+      .filter(([key]) => this.expose!.includes(key))
+
+    return Object.fromEntries(entries)
   }
 
   private push (key: string | null, data: Record<string, string>): void {

--- a/extensions/realtime/source/Routes.ts
+++ b/extensions/realtime/source/Routes.ts
@@ -3,6 +3,7 @@ import { console } from 'openspan'
 import { Connector } from '@toa.io/core'
 import { decode } from '@toa.io/generic'
 import { Receiver } from './Receiver'
+import type { Route } from './extension'
 import type { Bootloader } from './Factory'
 
 export class Routes extends Connector {
@@ -27,8 +28,8 @@ export class Routes extends Connector {
     const routes = Routes.read()
     const creating = []
 
-    for (const { event, properties } of routes) {
-      const consumer = this.boot.receive(event, new Receiver(event, properties, this.events))
+    for (const { event, properties, expose } of routes) {
+      const consumer = this.boot.receive(event, new Receiver(event, properties, this.events, expose))
 
       creating.push(consumer)
     }
@@ -58,7 +59,4 @@ class Events extends Readable {
   }
 }
 
-export interface Route {
-  event: string
-  properties: string[]
-}
+export type { Route }

--- a/extensions/realtime/source/extension.ts
+++ b/extensions/realtime/source/extension.ts
@@ -41,23 +41,41 @@ export function deployment (instances: Instances<Declaration>, annotation?: Decl
   return { services: [service] }
 }
 
-function parse (declaration: Declaration): Route[] {
+export function parse (declaration: Declaration): Route[] {
   const routes: Route[] = []
 
   for (const [event, value] of Object.entries(declaration)) {
-    const properties = Array.isArray(value) ? value : [value]
+    if (isObject(value)) {
+      const properties = Array.isArray(value.key) ? value.key : [value.key]
 
-    routes.push({ event, properties })
+      routes.push({ event, properties, expose: value.expose })
+    } else {
+      const properties = Array.isArray(value) ? value : [value]
+
+      routes.push({ event, properties })
+    }
   }
 
   return routes
 }
 
-type Declaration = Record<string, string | string[]>
+function isObject (value: Entry): value is RouteDeclaration {
+  return typeof value === 'object' && !Array.isArray(value)
+}
 
-interface Route {
+export type Entry = string | string[] | RouteDeclaration
+
+export type Declaration = Record<string, Entry>
+
+export interface RouteDeclaration {
+  key: string | string[]
+  expose?: string[]
+}
+
+export interface Route {
   event: string
   properties: string[]
+  expose?: string[]
 }
 
 interface Annotation {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes what data leaves the realtime layer for opted-in routes; misconfigured `expose` lists could leak extra fields or drop expected ones, though legacy routes still send the full payload.
> 
> **Overview**
> Realtime route manifests can now use an object form with **`key`** (routing fields, same as before) and optional **`expose`** to whitelist which payload fields are sent on each stream. Simple string/array route declarations are unchanged.
> 
> **`Receiver`** applies that filter before pushing events, so clients only see allowed properties (e.g. `text` and `sender`, not `recipient`). Deployment and test wiring pass **`expose`** through **`TOA_REALTIME`** via shared **`parse`** / **`Route`** types in **`extension.ts`**. A new Cucumber scenario covers the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa5960104388f6365e3f465da03e1270a2577389. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->