### PR TITLE
Alpha release

### DIFF
--- a/connectors/storages.mongodb/src/storage.js
+++ b/connectors/storages.mongodb/src/storage.js
@@ -35,6 +35,11 @@ class Storage extends Connector {
   async get (query) {
     const { criteria, options } = translate(query)
 
+    // identity lookups must return deleted records, so that callers
+    // can tell a deleted entity from a missing one
+    if (query?.id === undefined && query?.options?.deleted !== true)
+      criteria._deleted = null
+
     this.debug('findOne', { criteria, options })
 
     const record = await this.#collection.findOne(criteria, options)
@@ -69,6 +74,9 @@ class Storage extends Connector {
 
   async stream (query = undefined) {
     const { criteria, options } = translate(query)
+
+    if (query?.options?.deleted !== true)
+      criteria._deleted = null
 
     this.debug('find (stream)', { criteria, options })
 

--- a/connectors/storages.mongodb/test/storage.test.js
+++ b/connectors/storages.mongodb/test/storage.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const { Storage } = require('../src/storage')
+
+let collection
+let storage
+
+beforeEach(async () => {
+  collection = {
+    collectionName: 'test',
+    findOne: jest.fn(async () => null),
+    find: jest.fn(() => ({ stream: () => null }))
+  }
+
+  const client = {
+    collection,
+    link: () => null
+  }
+
+  storage = new Storage(client, { schema: { properties: {} } })
+
+  await storage.open()
+})
+
+describe('get', () => {
+  it('should filter deleted', async () => {
+    await storage.get({})
+
+    expect(collection.findOne).toHaveBeenCalledWith({ _deleted: null }, {})
+  })
+
+  it('should filter deleted with sort', async () => {
+    await storage.get({ options: { sort: [['_created', 'desc']] } })
+
+    expect(collection.findOne)
+      .toHaveBeenCalledWith({ _deleted: null }, { sort: [['_created', -1]] })
+  })
+
+  it('should not filter deleted if queried by id', async () => {
+    const id = 'bcb6780f50e243348cad40ed6b5ef575'
+
+    await storage.get({ id })
+
+    expect(collection.findOne).toHaveBeenCalledWith({ _id: id }, {})
+  })
+
+  it('should not filter deleted if requested', async () => {
+    await storage.get({ options: { deleted: true } })
+
+    expect(collection.findOne).toHaveBeenCalledWith({}, {})
+  })
+})
+
+describe('stream', () => {
+  it('should filter deleted', async () => {
+    await storage.stream()
+
+    expect(collection.find).toHaveBeenCalledWith({ _deleted: null }, {})
+  })
+
+  it('should filter deleted with sort', async () => {
+    await storage.stream({ options: { sort: [['_created', 'desc']] } })
+
+    expect(collection.find)
+      .toHaveBeenCalledWith({ _deleted: null }, { sort: [['_created', -1]] })
+  })
+
+  it('should not filter deleted if requested', async () => {
+    await storage.stream({ options: { deleted: true } })
+
+    expect(collection.find).toHaveBeenCalledWith({}, {})
+  })
+})

--- a/features/cli/env.feature
+++ b/features/cli/env.feature
@@ -134,7 +134,7 @@ Feature: Export local deployment environment variables
     Then program should exit with code 0
     And the environment variable TOA_CONFIGURATION__IDENTITY_TOKENS_KEY0 starts with 'k3.local.'
 
-  Scenario: Fill Cloudinary secrets from process environment with `--dev`
+  Scenario: Fill secrets from process environment by secret key with `--dev`
     Given I have a component `storage`
     And I have a context with:
       """yaml
@@ -151,8 +151,8 @@ Feature: Export local deployment environment variables
       """
     And environment variables:
       """
-      CLOUDINARY_API_KEY=cloud-key
-      CLOUDINARY_API_SECRET=cloud-secret
+      API_KEY=cloud-key
+      API_SECRET=cloud-secret
       """
     When I run `toa env --dev`
     Then the environment contains:
@@ -161,7 +161,7 @@ Feature: Export local deployment environment variables
       TOA_STORAGES_ASSETS_API_SECRET=cloud-secret
       """
 
-  Scenario: Throw when Cloudinary environment variables are missing with `--dev`
+  Scenario: Throw when secret key environment variables are missing with `--dev`
     Given I have a component `storage`
     And I have a context with:
       """yaml
@@ -180,10 +180,30 @@ Feature: Export local deployment environment variables
     Then program should exit with code 1
     And stderr should contain lines:
       """
-      CLOUDINARY_API_KEY is not set
+      toa-storages-assets/API_KEY, toa-storages-assets/API_SECRET is not set
       """
 
-  Scenario: Throw when unmapped secret is requested with `--dev`
+  Scenario: Fill configuration secret from process environment with `--dev`
+    Given I have a component `configuration.base`
+    And I have a context with:
+      """yaml
+      amqp:
+        context: amqp://whatever
+      configuration:
+        configuration.base:
+          foo: $FOO_VALUE
+      """
+    And environment variables:
+      """
+      FOO_VALUE=bar
+      """
+    When I run `toa env --dev`
+    Then the environment contains:
+      """
+      TOA_CONFIGURATION__FOO_VALUE=bar
+      """
+
+  Scenario: Throw when secret key is missing from process environment with `--dev`
     Given I have a component `configuration.base`
     And I have a context with:
       """yaml

--- a/features/operations/query.feature
+++ b/features/operations/query.feature
@@ -56,6 +56,34 @@ Feature: Query
       - id: 8754448197e64403878fb16d06020f0c
       """
 
+  Scenario: Observing skips deleted entries
+    Given the `mongo.one` database contains:
+      | _id                              | foo | bar   | _version | _created      | _deleted      |
+      | bcb6780f50e243348cad40ed6b5ef575 | 1   | hello | 1        | 1722011800000 | 1722011755487 |
+      | 72cf9b0ab0ac4ab2b8036e4e940ddcae | 2   | hello | 1        | 1722011700000 | null          |
+    And I boot `mongo.one` component
+    When I invoke `observe` with:
+      """yaml
+      query:
+        criteria: bar==hello
+        sort: [_created:desc]
+      """
+    Then the reply is received:
+      """
+      id: 72cf9b0ab0ac4ab2b8036e4e940ddcae
+      """
+    When I invoke `observe` with:
+      """yaml
+      query:
+        criteria: bar==hello
+        sort: [_created:desc]
+        deleted: true
+      """
+    Then the reply is received:
+      """
+      id: bcb6780f50e243348cad40ed6b5ef575
+      """
+
   Scenario: Querying sample
     Given the `mongo.one` database contains:
       | _id                              | foo | bar   | _version |

--- a/runtime/cli/src/handlers/env.js
+++ b/runtime/cli/src/handlers/env.js
@@ -111,9 +111,17 @@ async function resolveDevSecrets (variables) {
 
     const key = getKey(variable.secret)
 
-    if (!(key in DEV_SECRETS) || key in secrets) continue
+    if (key in secrets) continue
 
-    secrets[key] = await resolveDevSecret(key)
+    if (key in DEV_SECRETS) {
+      secrets[key] = await resolveDevSecret(key)
+      continue
+    }
+
+    const value = process.env[variable.secret.key]
+
+    if (value !== undefined && value !== '')
+      secrets[key] = value
   }
 
   return secrets
@@ -128,15 +136,6 @@ async function resolveDevSecret (key) {
 
   if (source.value !== undefined)
     return source.value
-
-  if (source.env !== undefined) {
-    const value = process.env[source.env]
-
-    if (value === undefined || value === '')
-      throw new Error(`${source.env} is not set`)
-
-    return value
-  }
 
   if (source.generate === true)
     return /** @type {string} */ (await V3.generateKey('local', { format: 'paserk' }))
@@ -189,17 +188,14 @@ function getKey (secret) {
 const SECRETS = {}
 
 /**
- * @type {Record<string, { value?: string, env?: string, generate?: boolean }>}
+ * @type {Record<string, { value?: string, generate?: boolean }>}
  */
 const DEV_SECRETS = {
   'toa-mongodb.default/username': { value: 'developer' },
   'toa-mongodb.default/password': { value: 'secret' },
   'toa-amqp-context.default/username': { value: 'developer' },
   'toa-amqp-context.default/password': { value: 'secret' },
-  'toa-storages-assets/API_KEY': { env: 'CLOUDINARY_API_KEY' },
-  'toa-storages-assets/API_SECRET': { env: 'CLOUDINARY_API_SECRET' },
-  'toa-configuration/IDENTITY_TOKENS_KEY0': { generate: true },
-  'toa-configuration/RESEND_KEY': { env: 'RESEND_KEY' }
+  'toa-configuration/IDENTITY_TOKENS_KEY0': { generate: true }
 }
 
 exports.env = env


### PR DESCRIPTION
- fix `env -d`
- fix deleted entity observation without `query.id`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Mongo read/stream semantics for non-id queries and alters how local dev secrets are sourced, which can break workflows that relied on `CLOUDINARY_*` env names or on seeing deleted documents through `get`/`stream`.
> 
> **Overview**
> **MongoDB storage** now applies the same soft-delete filter as `find` on **`get`** and **`stream`**: queries add `_deleted: null` unless the lookup is by **`id`** (so callers can still distinguish deleted vs missing) or **`options.deleted === true`**. Unit tests lock in criteria passed to `findOne`/`find`.
> 
> **`toa env --dev`** no longer maps Cloudinary/Resend secrets to fixed env var names. Built-in dev secrets (Mongo/AMQP creds, generated identity key) stay in `DEV_SECRETS`; everything else is read from **`process.env[secret.key]`** (e.g. `API_KEY`, `FOO_VALUE`). Missing values still fail via `assertNoPendingSecrets` with **`name/key`** style errors. BDD scenarios cover storage assets, configuration secrets, and **observe** skipping deleted Mongo rows unless `deleted: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb9c9da069b6156148f32bdd80795cd39d4190d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->