### PR TITLE
perf(operations): speed up service rollout

### DIFF
--- a/extensions/exposition/source/HTTP/Server.ts
+++ b/extensions/exposition/source/HTTP/Server.ts
@@ -60,12 +60,20 @@ export class Server extends Connector {
   }
 
   protected override async close (): Promise<void> {
-    this.server.close()
     this.ready = false
+
+    this.server.close()
+    this.server.closeIdleConnections()
 
     console.info('Stopped accepting new connections')
 
-    await once(this.server, 'close')
+    // keep-alive clients hold connections open indefinitely, so the drain is bounded
+    await Promise.race([
+      once(this.server, 'close'),
+      setTimeout(this.properties.drain, undefined, { ref: false })
+    ])
+
+    this.server.closeAllConnections()
 
     console.info('Stopped')
   }
@@ -222,13 +230,15 @@ function errorAttributes (request: http.IncomingMessage, error: Error & any): Re
 
 export const PORT = 8000
 export const DELAY = 3 // seconds
+export const DRAIN = 10 // seconds
 
 const DEFAULTS: Omit<Properties, 'authorities'> = {
   methods: new Set<string>(['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'LOCK', 'UNLOCK']),
   debug: false,
   trace: false,
   port: PORT,
-  delay: DELAY * 1000
+  delay: DELAY * 1000,
+  drain: DRAIN * 1000
 }
 
 interface Properties {
@@ -238,6 +248,7 @@ interface Properties {
   trace: boolean
   port: number
   delay: number
+  drain: number
 }
 
 export type Options = { authorities: Properties['authorities'] } & {

--- a/features/deployment/templates/services.feature
+++ b/features/deployment/templates/services.feature
@@ -5,6 +5,8 @@ Feature: Service Deployment
     And I have a context with:
       """yaml
       exposition:
+        authorities:
+          local: api.dev
         /:
           GET:
             dev:stub: ok!
@@ -54,11 +56,13 @@ Feature: Service Deployment
       - host: api.bar.dev
       """
 
-  Scenario: Deploy a service with probe
+  Scenario: Deploy a service with probes
     Given I have a component `exposed.one`
     And I have a context with:
       """yaml
       exposition:
+        authorities:
+          local: api.dev
         /:
           GET:
             dev:stub: ok!
@@ -71,9 +75,73 @@ Feature: Service Deployment
     Then program should exit
     And extension-exposition-gateway Deployment container spec should contain:
       """
+      startupProbe:
+        httpGet:
+          path: /.ready
+          port: 8000
+        initialDelaySeconds: 3
+        periodSeconds: 2
+        timeoutSeconds: 3
+        failureThreshold: 150
       readinessProbe:
         httpGet:
           path: /.ready
           port: 8000
-        initialDelaySeconds: 1
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 3
+      """
+
+  Scenario: Replicas are replaced in parallel
+    Given I have a component `exposed.one`
+    And I have a context with:
+      """yaml
+      exposition:
+        authorities:
+          local: api.dev
+        /:
+          GET:
+            dev:stub: ok!
+      configuration:
+        identity.tokens:
+          key0: secret.key
+      """
+    When I export deployment for dev
+    And I run `helm template deployment`
+    Then program should exit
+    And extension-exposition-gateway Deployment strategy spec should contain:
+      """
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 50%
+        maxSurge: 50%
+      """
+
+  Scenario: Deploy a service with connection draining
+    Given I have a component `exposed.one`
+    And I have a context with:
+      """yaml
+      exposition:
+        authorities:
+          local: api.dev
+        /:
+          GET:
+            dev:stub: ok!
+      configuration:
+        identity.tokens:
+          key0: secret.key
+      """
+    When I export deployment for dev
+    And I run `helm template deployment`
+    Then program should exit
+    And extension-exposition-gateway Deployment container spec should contain:
+      """
+      lifecycle:
+        preStop:
+          exec:
+            command: [sleep, "5"]
+      """
+    And extension-exposition-gateway Deployment template.spec spec should contain:
+      """
+      terminationGracePeriodSeconds: 45
       """

--- a/features/steps/kubespec.js
+++ b/features/steps/kubespec.js
@@ -27,6 +27,7 @@ Then('{word} {word} {word} spec should contain:',
 const extract = (spec, node) => {
   if (node === 'container') return spec.spec.template.spec.containers[0]
   if (node === 'template.spec') return spec.spec.template.spec
+  if (node === 'strategy') return spec.spec.strategy
   if (node === 'rules') return spec.spec.rules
 
   throw new Error(`Unknown node '${node}'`)

--- a/operations/src/deployment/chart/templates/services.yaml
+++ b/operations/src/deployment/chart/templates/services.yaml
@@ -5,6 +5,11 @@ metadata:
   name: extension-{{ required "deployment name is required" .name }}
 spec:
   replicas: {{ .replicas | default 2 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 50%
   selector:
     matchLabels:
       toa.io/service: extension-{{ .name }}
@@ -42,14 +47,29 @@ spec:
             {{- end }}
           {{- end }}
           {{- if .probe }}
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: {{ .probe.path }}
               port: {{ .probe.port }}
             {{- if .probe.delay }}
             initialDelaySeconds: {{ .probe.delay }}
             {{- end }}
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 150
+          readinessProbe:
+            httpGet:
+              path: {{ .probe.path }}
+              port: {{ .probe.port }}
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [sleep, "5"]
+      terminationGracePeriodSeconds: 45
 {{- if .port }}
 ---
 apiVersion: v1

--- a/runtime/cli/src/handlers/lib/graceful.js
+++ b/runtime/cli/src/handlers/lib/graceful.js
@@ -7,7 +7,7 @@ function graceful (connector) {
     .forEach(signal => process.once(signal, async () => {
       console.info('Shutting down', { signal })
 
-      await connector.disconnect(true)
+      await connector.disconnect()
 
       process.exit(0)
     }))


### PR DESCRIPTION
Rolling out `extension-exposition-gateway` took about 6 minutes on a live cluster, which is longer than helm's default 5 minute `--wait` timeout, so deploys reported `context deadline exceeded` and got rolled back manually — another full rollout on top.

## Measurements

Timings from the gateway pods of one rollout:

- pod A created 11:24:53, ready 11:28:04 — 3m09s
- pod B created 11:28:04 (only after A became ready), ready 11:30:52 — 2m47s

Of pod B's 2m47s, **44 seconds were spent purely waiting on the readiness probe**: the app logged `Composition complete` at 11:30:04 and was serving by ~11:30:08, but the pod was not marked ready until 11:30:52. Pod events show `Readiness probe failed: context deadline exceeded (Client.Timeout exceeded while awaiting headers)` — the 1s default `timeoutSeconds` is not enough for an event loop busy booting, and each miss costs another `periodSeconds: 10`.

## Changes

**Rollout is no longer serialized.** No `strategy` was set, so with `replicas: 2` Kubernetes computed `maxUnavailable = 25%` rounded down to 0 and `maxSurge = 25%` rounded up to 1 — pods could only be replaced one at a time. An explicit `50%`/`50%` gives 1 and 1: one pod always serves traffic, at most 3 pods exist at once, and both replicas boot in parallel.

**Probes are split.** A `startupProbe` polling every 2s with a 300s budget takes over the boot window, and the `readinessProbe` gets `timeoutSeconds: 3`. The pod now becomes ready within ~2s of actually being ready.

**Connection draining.** `Connector.disconnect` skips `close()` when `interrupt` is set, and `interrupt` exists to abort a *failed* connection — `connect()` uses it in its own catch block. `graceful` was passing it on SIGTERM, so for the exposition gateway (whose root connector is the HTTP `Server`) the server was never closed: it kept listening, `/.ready` kept returning 200 throughout shutdown, and in-flight requests were cut by `process.exit(0)`. Now `close()` runs, idle keep-alive connections are closed immediately, and the drain is bounded by a deadline before the remaining sockets are destroyed. A `preStop` delay and a termination grace period give the ingress time to drop the endpoint first.

Compositions are unaffected by the `graceful` change: `Composition` does not override `close()`.

## Notes

`features/deployment/templates/services.feature` was already failing before this change — the exposition annotation schema requires `authorities`, which four scenarios did not set, and the probe scenario still expected the long-gone `initialDelaySeconds: 1`. Both are fixed here, so the file passes again.

## Verification

- `npx cucumber-js features/deployment/templates/services.feature` — 5 scenarios passed, including new ones for the strategy and for draining
- `npx jest features/steps/.test/kubespec.test.js operations/src/deployment` — passed
- `tsc --noEmit` on `extensions/exposition` and `eslint` on the changed TypeScript — clean

Only the exposition extension declares a `probe`, so the probe changes affect just the gateway; `preStop` and the grace period apply to all services.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SIGTERM shutdown for all CLI compositions and changes Kubernetes rollout/probe behavior fleet-wide for extension services; HTTP drain logic is bounded but mis-tuning could still cut long requests on gateway shutdown.
> 
> **Overview**
> **Rollouts and readiness** — Helm deployments now use explicit **RollingUpdate** with **50% maxUnavailable / 50% maxSurge** so two-replica services replace pods in parallel instead of one-at-a-time. **startupProbe** and tuned **readinessProbe** (`timeoutSeconds: 3`, separate periods) replace a single readiness probe so pods mark ready soon after the app is actually serving.
> 
> **Graceful shutdown** — `graceful` now calls `connector.disconnect()` without the interrupt flag so the exposition HTTP `Server` runs **`close()`**: `ready` clears first, idle keep-alive connections close immediately, drain waits up to a new configurable **`drain`** deadline (default 10s), then **`closeAllConnections()`**. Chart adds **`preStop` sleep (5s)** and **`terminationGracePeriodSeconds: 45`** on all extension services so ingress can drop endpoints before the process exits.
> 
> **Tests** — Deployment feature scenarios gain required **`authorities`**, assertions for strategy/probes/draining, and **`kubespec`** support for the deployment **strategy** node.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c4e072627b006e18b3e9591077868447ddd6b0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->