### PR TITLE
Alpha release

### DIFF
--- a/extensions/exposition/source/HTTP/Server.ts
+++ b/extensions/exposition/source/HTTP/Server.ts
@@ -60,12 +60,20 @@ export class Server extends Connector {
   }
 
   protected override async close (): Promise<void> {
-    this.server.close()
     this.ready = false
+
+    this.server.close()
+    this.server.closeIdleConnections()
 
     console.info('Stopped accepting new connections')
 
-    await once(this.server, 'close')
+    // keep-alive clients hold connections open indefinitely, so the drain is bounded
+    await Promise.race([
+      once(this.server, 'close'),
+      setTimeout(this.properties.drain, undefined, { ref: false })
+    ])
+
+    this.server.closeAllConnections()
 
     console.info('Stopped')
   }
@@ -222,13 +230,15 @@ function errorAttributes (request: http.IncomingMessage, error: Error & any): Re
 
 export const PORT = 8000
 export const DELAY = 3 // seconds
+export const DRAIN = 10 // seconds
 
 const DEFAULTS: Omit<Properties, 'authorities'> = {
   methods: new Set<string>(['OPTIONS', 'GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'LOCK', 'UNLOCK']),
   debug: false,
   trace: false,
   port: PORT,
-  delay: DELAY * 1000
+  delay: DELAY * 1000,
+  drain: DRAIN * 1000
 }
 
 interface Properties {
@@ -238,6 +248,7 @@ interface Properties {
   trace: boolean
   port: number
   delay: number
+  drain: number
 }
 
 export type Options = { authorities: Properties['authorities'] } & {

--- a/features/deployment/templates/services.feature
+++ b/features/deployment/templates/services.feature
@@ -5,6 +5,8 @@ Feature: Service Deployment
     And I have a context with:
       """yaml
       exposition:
+        authorities:
+          local: api.dev
         /:
           GET:
             dev:stub: ok!
@@ -54,11 +56,13 @@ Feature: Service Deployment
       - host: api.bar.dev
       """
 
-  Scenario: Deploy a service with probe
+  Scenario: Deploy a service with probes
     Given I have a component `exposed.one`
     And I have a context with:
       """yaml
       exposition:
+        authorities:
+          local: api.dev
         /:
           GET:
             dev:stub: ok!
@@ -71,9 +75,73 @@ Feature: Service Deployment
     Then program should exit
     And extension-exposition-gateway Deployment container spec should contain:
       """
+      startupProbe:
+        httpGet:
+          path: /.ready
+          port: 8000
+        initialDelaySeconds: 3
+        periodSeconds: 2
+        timeoutSeconds: 3
+        failureThreshold: 150
       readinessProbe:
         httpGet:
           path: /.ready
           port: 8000
-        initialDelaySeconds: 1
+        periodSeconds: 10
+        timeoutSeconds: 3
+        failureThreshold: 3
+      """
+
+  Scenario: Replicas are replaced in parallel
+    Given I have a component `exposed.one`
+    And I have a context with:
+      """yaml
+      exposition:
+        authorities:
+          local: api.dev
+        /:
+          GET:
+            dev:stub: ok!
+      configuration:
+        identity.tokens:
+          key0: secret.key
+      """
+    When I export deployment for dev
+    And I run `helm template deployment`
+    Then program should exit
+    And extension-exposition-gateway Deployment strategy spec should contain:
+      """
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 50%
+        maxSurge: 50%
+      """
+
+  Scenario: Deploy a service with connection draining
+    Given I have a component `exposed.one`
+    And I have a context with:
+      """yaml
+      exposition:
+        authorities:
+          local: api.dev
+        /:
+          GET:
+            dev:stub: ok!
+      configuration:
+        identity.tokens:
+          key0: secret.key
+      """
+    When I export deployment for dev
+    And I run `helm template deployment`
+    Then program should exit
+    And extension-exposition-gateway Deployment container spec should contain:
+      """
+      lifecycle:
+        preStop:
+          exec:
+            command: [sleep, "5"]
+      """
+    And extension-exposition-gateway Deployment template.spec spec should contain:
+      """
+      terminationGracePeriodSeconds: 45
       """

--- a/features/steps/kubespec.js
+++ b/features/steps/kubespec.js
@@ -27,6 +27,7 @@ Then('{word} {word} {word} spec should contain:',
 const extract = (spec, node) => {
   if (node === 'container') return spec.spec.template.spec.containers[0]
   if (node === 'template.spec') return spec.spec.template.spec
+  if (node === 'strategy') return spec.spec.strategy
   if (node === 'rules') return spec.spec.rules
 
   throw new Error(`Unknown node '${node}'`)

--- a/operations/src/deployment/chart/templates/services.yaml
+++ b/operations/src/deployment/chart/templates/services.yaml
@@ -5,6 +5,11 @@ metadata:
   name: extension-{{ required "deployment name is required" .name }}
 spec:
   replicas: {{ .replicas | default 2 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 50%
   selector:
     matchLabels:
       toa.io/service: extension-{{ .name }}
@@ -42,14 +47,29 @@ spec:
             {{- end }}
           {{- end }}
           {{- if .probe }}
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: {{ .probe.path }}
               port: {{ .probe.port }}
             {{- if .probe.delay }}
             initialDelaySeconds: {{ .probe.delay }}
             {{- end }}
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 150
+          readinessProbe:
+            httpGet:
+              path: {{ .probe.path }}
+              port: {{ .probe.port }}
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command: [sleep, "5"]
+      terminationGracePeriodSeconds: 45
 {{- if .port }}
 ---
 apiVersion: v1

--- a/runtime/cli/src/handlers/lib/graceful.js
+++ b/runtime/cli/src/handlers/lib/graceful.js
@@ -7,7 +7,7 @@ function graceful (connector) {
     .forEach(signal => process.once(signal, async () => {
       console.info('Shutting down', { signal })
 
-      await connector.disconnect(true)
+      await connector.disconnect()
 
       process.exit(0)
     }))


### PR DESCRIPTION
- speed up deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown and rollout behavior for live traffic paths (connection teardown timing and parallel pod replacement); misaligned grace periods could still cut requests if drain exceeds K8s limits.
> 
> **Overview**
> Speeds up service rollouts by allowing **parallel replica replacement** and aligning pod shutdown with **bounded HTTP connection draining**.
> 
> The exposition HTTP server **`close()`** now stops accepting work immediately (`ready = false`), calls `close()` / `closeIdleConnections()`, waits for the server `close` event **or** a new configurable **`drain`** timeout (default 10s), then **`closeAllConnections()`** so keep-alive clients cannot block shutdown indefinitely.
> 
> Helm service deployments add **`RollingUpdate`** with **50% maxUnavailable / maxSurge**, a **`startupProbe`** on `/.ready` (separate from readiness timing), **`preStop` sleep 5**, and **`terminationGracePeriodSeconds: 45`** to give in-flight requests time to finish. Runtime **SIGTERM/SIGINT** handling calls **`connector.disconnect()`** without the previous forced flag so shutdown follows the new drain path.
> 
> Cucumber coverage asserts probes, rolling strategy, and lifecycle fields; **`kubespec`** can assert deployment **strategy** specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661866a7df0c317081a6309446bfde4ccf5e009f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->