### PR TITLE
perf(operations): progressDeadlineSeconds and mail resources

### DIFF
--- a/extensions/mail/source/Annotation.ts
+++ b/extensions/mail/source/Annotation.ts
@@ -1,5 +1,5 @@
+import type { Resources } from '@toa.io/operations'
+
 export interface Annotation {
-  provider: string
-  from: string
-  templates?: string
+  resources?: Resources
 }

--- a/extensions/mail/source/deployment.ts
+++ b/extensions/mail/source/deployment.ts
@@ -1,7 +1,8 @@
 import { components } from './Composition'
+import type { Annotation } from './Annotation'
 import type { Dependency, Service } from '@toa.io/operations'
 
-export function deployment (): Dependency {
+export function deployment (_: unknown, annotation?: Annotation): Dependency {
   const labels = components().labels
 
   const service: Service = {
@@ -10,7 +11,8 @@ export function deployment (): Dependency {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     version: require('../package.json').version,
     variables: [],
-    components: labels
+    components: labels,
+    resources: annotation?.resources
   }
 
   return { services: [service] }

--- a/features/deployment/templates/services.feature
+++ b/features/deployment/templates/services.feature
@@ -116,6 +116,10 @@ Feature: Service Deployment
         maxUnavailable: 50%
         maxSurge: 50%
       """
+    And extension-exposition-gateway Deployment spec spec should contain:
+      """
+      progressDeadlineSeconds: 900
+      """
 
   Scenario: Deploy a service with connection draining
     Given I have a component `exposed.one`

--- a/features/steps/kubespec.js
+++ b/features/steps/kubespec.js
@@ -28,6 +28,7 @@ const extract = (spec, node) => {
   if (node === 'container') return spec.spec.template.spec.containers[0]
   if (node === 'template.spec') return spec.spec.template.spec
   if (node === 'strategy') return spec.spec.strategy
+  if (node === 'spec') return spec.spec
   if (node === 'rules') return spec.spec.rules
 
   throw new Error(`Unknown node '${node}'`)

--- a/operations/src/deployment/chart/templates/compositions.yaml
+++ b/operations/src/deployment/chart/templates/compositions.yaml
@@ -5,6 +5,9 @@ metadata:
   name: composition-{{ required "composition name is required" .name }}
 spec:
   replicas: {{ .replicas | default 2 }}
+  # A backstop for stuck rollouts only. Must stay above the `helm upgrade --timeout`
+  # the deploy runs with, so a slow but progressing rollout is not marked failed.
+  progressDeadlineSeconds: 900
   selector:
     matchLabels:
       toa.io/composition: {{ .name }}

--- a/operations/src/deployment/chart/templates/services.yaml
+++ b/operations/src/deployment/chart/templates/services.yaml
@@ -5,6 +5,9 @@ metadata:
   name: extension-{{ required "deployment name is required" .name }}
 spec:
   replicas: {{ .replicas | default 2 }}
+  # A backstop for stuck rollouts only. Must stay above the `helm upgrade --timeout`
+  # the deploy runs with, so a slow but progressing rollout is not marked failed.
+  progressDeadlineSeconds: 900
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
## Summary
- Set `progressDeadlineSeconds: 900` on service and composition Deployments so it sits above the helm `--timeout` (8m) and only fires on stuck rollouts.
- Accept `resources` on the mail annotation (same shape as realtime) so `extension-mail-agent` can leave BestEffort.

## Test plan
- [x] `npx cucumber-js features/deployment/templates/services.feature` (5 passed)

Made with [Cursor](https://cursor.com)