### PR TITLE
perf(operations): speed up Docker deploy builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      packages: write
 
     steps:
       - name: Setup Node
@@ -74,6 +75,38 @@ jobs:
           else
             npx lerna publish --conventional-prerelease --preid alpha --dist-tag alpha --no-commit-hooks --no-changelog --yes --message "ci: %s" --sign-git-commit
           fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish runtime image
+        run: |
+          VERSION=$(node -p "require('./runtime/runtime/package.json').version")
+          IMAGE=ghcr.io/toa-io/runtime
+          TAGS=(--tag "$IMAGE:$VERSION")
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAGS+=(--tag "$IMAGE:${{ inputs.dist-tag }}")
+          elif [ "${{ github.base_ref }}" = "release" ]; then
+            TAGS+=(--tag "$IMAGE:latest")
+          else
+            TAGS+=(--tag "$IMAGE:alpha")
+          fi
+
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-arg VERSION="$VERSION" \
+            "${TAGS[@]}" \
+            --push \
+            -f operations/image/runtime.Dockerfile \
+            operations/image
 
       - name: Push to dev branch
         if: github.event_name == 'pull_request'

--- a/operations/image/runtime.Dockerfile
+++ b/operations/image/runtime.Dockerfile
@@ -1,0 +1,4 @@
+FROM node:24.14.0-alpine3.22
+
+ARG VERSION
+RUN npm i -g @toa.io/runtime@${VERSION} --omit=dev

--- a/operations/readme.md
+++ b/operations/readme.md
@@ -4,6 +4,22 @@
 
 ### Container Registry
 
+Deploy images default to `FROM ghcr.io/toa-io/runtime:<runtime.version>`
+(published with each Toa release). The base image already has `@toa.io/runtime`
+installed; composition/service Dockerfiles only install component dependencies.
+
+To use a custom base image, set `registry.build.image` (or `composition.image`).
+That image must provide the `toa` CLI, or install it via `registry.build.run`:
+
+```yaml
+# context.toa.yaml
+
+registry:
+  build:
+    image: node:24.14.0-alpine3.22
+    run: npm i -g @toa.io/runtime --omit=dev
+```
+
 #### Build Options
 
 ```yaml

--- a/operations/src/deployment/factory.js
+++ b/operations/src/deployment/factory.js
@@ -22,7 +22,7 @@ class Factory {
 
     const imagesFactory = new ImagesFactory(context.name, context.runtime, context.registry)
 
-    this.#registry = new Registry(context.registry, imagesFactory, this.#process)
+    this.#registry = new Registry(context.name, context.registry, imagesFactory, this.#process)
     this.#compositions = context.compositions.map((composition) => this.#composition(composition))
     this.#dependencies = this.#getDependencies()
   }

--- a/operations/src/deployment/images/composition.Dockerfile
+++ b/operations/src/deployment/images/composition.Dockerfile
@@ -5,8 +5,6 @@ FROM {{build.image}}
 ENV NODE_ENV=production
 RUN if [ "{{runtime.registry}}" != "" ]; then npm set registry {{runtime.registry}}; fi
 RUN if [ "{{runtime.proxy}}" != "" ]; then npm set proxy {{runtime.proxy}}; fi
-RUN --mount=type=cache,target=/root/.npm \
-  npm i -g @toa.io/runtime@{{runtime.version}} --omit=dev
 
 WORKDIR /composition
 COPY --chown=node:node . /composition

--- a/operations/src/deployment/images/composition.Dockerfile
+++ b/operations/src/deployment/images/composition.Dockerfile
@@ -5,7 +5,8 @@ FROM {{build.image}}
 ENV NODE_ENV=production
 RUN if [ "{{runtime.registry}}" != "" ]; then npm set registry {{runtime.registry}}; fi
 RUN if [ "{{runtime.proxy}}" != "" ]; then npm set proxy {{runtime.proxy}}; fi
-RUN npm i -g @toa.io/runtime@{{runtime.version}} --omit=dev
+RUN --mount=type=cache,target=/root/.npm \
+  npm i -g @toa.io/runtime@{{runtime.version}} --omit=dev
 
 WORKDIR /composition
 COPY --chown=node:node . /composition
@@ -13,7 +14,8 @@ COPY --chown=node:node . /composition
 {{build.run}}
 
 # run 'npm i' in each component
-RUN for entry in *; do if [ -f "$entry/package.json" ]; then (cd $entry && npm i --omit=dev); fi; done
+RUN --mount=type=cache,target=/root/.npm \
+  for entry in *; do if [ -f "$entry/package.json" ]; then (cd $entry && npm i --omit=dev); fi; done
 
 USER node
 CMD toa compose *

--- a/operations/src/deployment/images/image.js
+++ b/operations/src/deployment/images/image.js
@@ -26,9 +26,7 @@ class Image {
   #registry
   #runtime
   #values = {
-    build: {
-      image: 'node:24.14.0-alpine3.22'
-    }
+    build: {}
   }
 
   constructor (scope, runtime, registry) {
@@ -79,7 +77,9 @@ class Image {
 
   #setValues () {
     this.#values.runtime = this.#runtime
-    this.#values.build = overwrite(this.#values.build, this.#registry.build)
+    this.#values.build = overwrite({
+      image: `${RUNTIME_IMAGE}:${this.#runtime.version}`
+    }, this.#registry.build)
 
     const image = this.base
 
@@ -127,4 +127,7 @@ function createArguments (variables) {
   return args.join('\n')
 }
 
+const RUNTIME_IMAGE = 'ghcr.io/toa-io/runtime'
+
 exports.Image = Image
+exports.RUNTIME_IMAGE = RUNTIME_IMAGE

--- a/operations/src/deployment/images/runtime-base.test.js
+++ b/operations/src/deployment/images/runtime-base.test.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const { join } = require('node:path')
+const { readFile } = require('node:fs/promises')
+const { directory } = require('@toa.io/filesystem')
+
+const { Image, RUNTIME_IMAGE } = require('./image')
+
+const compositionDockerfile = join(__dirname, 'composition.Dockerfile')
+const serviceDockerfile = join(__dirname, 'service.Dockerfile')
+
+class TestImage extends Image {
+  dockerfile
+
+  #name
+  #base
+
+  constructor (runtime, registry, dockerfile, name = 'test', base) {
+    super('acme', runtime, registry)
+
+    this.dockerfile = dockerfile
+    this.#name = name
+    this.#base = base
+  }
+
+  get name () {
+    return this.#name
+  }
+
+  get version () {
+    return 'abcdef12'
+  }
+
+  get base () {
+    return this.#base
+  }
+}
+
+describe('runtime base image', () => {
+  /** @type {string} */
+  let root
+
+  beforeEach(async () => {
+    root = await directory.temp('toa-runtime-base-test')
+  })
+
+  it('should default build.image to version-pinned GHCR runtime image', async () => {
+    const runtime = { version: '1.0.0-alpha.232' }
+    const image = new TestImage(runtime, {}, compositionDockerfile)
+
+    const path = await image.prepare(root)
+    const dockerfile = await readFile(join(path, 'Dockerfile'), 'utf8')
+
+    expect(dockerfile).toContain(`FROM ${RUNTIME_IMAGE}:1.0.0-alpha.232`)
+    expect(dockerfile).not.toMatch(/npm i -g @toa\.io\/runtime/)
+  })
+
+  it('should not install runtime in service Dockerfile template', async () => {
+    const runtime = { version: '1.0.0-alpha.99' }
+    const image = new TestImage(runtime, {}, serviceDockerfile, 'service-test')
+
+    const path = await image.prepare(root)
+    const dockerfile = await readFile(join(path, 'Dockerfile'), 'utf8')
+
+    expect(dockerfile).toContain(`FROM ${RUNTIME_IMAGE}:1.0.0-alpha.99`)
+    expect(dockerfile).not.toMatch(/npm i -g @toa\.io\/runtime/)
+  })
+
+  it('should allow registry.build.image override', async () => {
+    const runtime = { version: '1.0.0-alpha.232' }
+    const registry = { build: { image: 'node:24.14.0-alpine3.22' } }
+    const image = new TestImage(runtime, registry, compositionDockerfile)
+
+    const path = await image.prepare(root)
+    const dockerfile = await readFile(join(path, 'Dockerfile'), 'utf8')
+
+    expect(dockerfile).toContain('FROM node:24.14.0-alpine3.22')
+    expect(dockerfile).not.toContain(RUNTIME_IMAGE)
+  })
+
+  it('should allow composition.image override via base', async () => {
+    const runtime = { version: '1.0.0-alpha.232' }
+    const image = new TestImage(runtime, {}, compositionDockerfile, 'mono', 'custom.example/base:1')
+
+    const path = await image.prepare(root)
+    const dockerfile = await readFile(join(path, 'Dockerfile'), 'utf8')
+
+    expect(dockerfile).toContain('FROM custom.example/base:1')
+  })
+})

--- a/operations/src/deployment/images/service.Dockerfile
+++ b/operations/src/deployment/images/service.Dockerfile
@@ -3,8 +3,6 @@ FROM {{build.image}}
 ENV NODE_ENV=production
 RUN if [ "{{runtime.registry}}" != "" ]; then npm set registry {{runtime.registry}}; fi
 RUN if [ "{{runtime.proxy}}" != "" ]; then npm set proxy {{runtime.proxy}}; fi
-RUN --mount=type=cache,target=/root/.npm \
-  npm i -g @toa.io/runtime@{{runtime.version}} --omit=dev
 
 WORKDIR /service
 COPY --chown=node:node . /service

--- a/operations/src/deployment/images/service.Dockerfile
+++ b/operations/src/deployment/images/service.Dockerfile
@@ -3,12 +3,14 @@ FROM {{build.image}}
 ENV NODE_ENV=production
 RUN if [ "{{runtime.registry}}" != "" ]; then npm set registry {{runtime.registry}}; fi
 RUN if [ "{{runtime.proxy}}" != "" ]; then npm set proxy {{runtime.proxy}}; fi
-RUN npm i -g @toa.io/runtime@{{runtime.version}} --omit=dev
+RUN --mount=type=cache,target=/root/.npm \
+  npm i -g @toa.io/runtime@{{runtime.version}} --omit=dev
 
 WORKDIR /service
 COPY --chown=node:node . /service
 
-RUN npm i --omit=dev
+RUN --mount=type=cache,target=/root/.npm \
+  npm i --omit=dev
 
 USER node
 CMD toa serve .

--- a/operations/src/deployment/registry.js
+++ b/operations/src/deployment/registry.js
@@ -1,12 +1,14 @@
 'use strict'
 
+const { posix } = require('node:path')
 const workspace = require('./workspace')
-const { newid } = require('@toa.io/generic')
 
 /**
  * @implements {toa.deployment.Registry}
  */
 class Registry {
+  #scope
+
   #registry
 
   #factory
@@ -15,7 +17,11 @@ class Registry {
 
   #images = []
 
-  constructor (registry, factory, process) {
+  /** @type {string | undefined} */
+  #builder
+
+  constructor (scope, registry, factory, process) {
+    this.#scope = scope
     this.#registry = registry
     this.#factory = factory
     this.#process = process
@@ -40,9 +46,8 @@ class Registry {
   async build () {
     await this.prepare()
 
-    for (const image of this.#images) {
+    for (const image of this.#images)
       await this.#build(image)
-    }
   }
 
   async push () {
@@ -81,11 +86,10 @@ class Registry {
 
     const args = ['--context=default', 'buildx', 'build']
 
-    if (push) {
+    if (push)
       args.push('--push')
-    } else {
+    else
       args.push('--load')
-    }
 
     args.push('--tag', image.reference, image.context)
 
@@ -97,13 +101,15 @@ class Registry {
 
     if (multiarch) {
       const platform = this.#registry.platforms.join(',')
-      const builder = await this.#createBuilder()
+      const builder = await this.#ensureBuilder()
 
       args.push('--platform', platform)
       args.push('--builder', builder)
-    } else {
+
+      if (this.#registry.base !== undefined)
+        this.#appendCache(args)
+    } else
       args.push('--builder', 'default')
-    }
 
     args.push('--progress', 'plain')
 
@@ -128,13 +134,29 @@ class Registry {
     return true
   }
 
-  async #createBuilder () {
-    const name = `toa-${newid()}`
-    const create = `buildx create --name ${name} --bootstrap --use`.split(' ')
+  async #ensureBuilder () {
+    if (this.#builder !== undefined)
+      return this.#builder
 
-    await this.#process.execute('docker', create)
+    try {
+      await this.#process.execute('docker', ['buildx', 'inspect', BUILDER], { silently: true })
+    } catch {
+      await this.#process.execute('docker', ['buildx', 'create', '--name', BUILDER, '--bootstrap'])
+    }
 
-    return name
+    this.#builder = BUILDER
+
+    return BUILDER
+  }
+
+  /**
+   * @param {string[]} args
+   */
+  #appendCache (args) {
+    const ref = posix.join(this.#registry.base, this.#scope, 'buildcache')
+
+    args.push('--cache-from', `type=registry,ref=${ref}`)
+    args.push('--cache-to', `type=registry,ref=${ref},mode=max,image-manifest=true`)
   }
 }
 

--- a/operations/src/deployment/registry.test.js
+++ b/operations/src/deployment/registry.test.js
@@ -1,0 +1,175 @@
+'use strict'
+
+const { Registry } = require('./registry')
+
+/** @type {toa.operations.Process} */
+let process
+
+/** @type {toa.deployment.images.Factory} */
+let factory
+
+/** @type {toa.deployment.images.Image[]} */
+let images
+
+beforeEach(() => {
+  images = []
+  process = /** @type {toa.operations.Process} */ {
+    execute: jest.fn(async (cmd, args) => {
+      if (args[0] === 'manifest')
+        throw new Error('manifest unknown')
+
+      if (args[0] === 'buildx' && args[1] === 'inspect')
+        throw new Error('builder not found')
+
+      return ''
+    })
+  }
+
+  factory = /** @type {toa.deployment.images.Factory} */ {
+    composition: () => createImage('composition-mono'),
+    service: () => createImage('extension-realtime')
+  }
+})
+
+it('should reuse named builder across images', async () => {
+  const registry = createRegistry({ base: 'example.com/reg', platforms: ['linux/amd64'] })
+
+  registry.composition(/** @type {any} */ ({}))
+  registry.service('.', /** @type {any} */ ({}))
+
+  await registry.build()
+
+  const creates = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === 'buildx' && args[1] === 'create')
+
+  expect(creates).toHaveLength(1)
+  expect(creates[0][1]).toEqual(['buildx', 'create', '--name', 'toa', '--bootstrap'])
+
+  const builds = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === '--context=default' && args[1] === 'buildx' && args[2] === 'build')
+
+  expect(builds).toHaveLength(2)
+
+  for (const [, args] of builds) {
+    expect(args).toContain('--builder')
+    expect(args[args.indexOf('--builder') + 1]).toBe('toa')
+  }
+})
+
+it('should not create builder when it already exists', async () => {
+  process.execute = jest.fn(async (cmd, args) => {
+    if (args[0] === 'manifest')
+      throw new Error('manifest unknown')
+
+    return ''
+  })
+
+  const registry = createRegistry({ base: 'example.com/reg', platforms: ['linux/amd64'] })
+
+  registry.composition(/** @type {any} */ ({}))
+
+  await registry.build()
+
+  const creates = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === 'buildx' && args[1] === 'create')
+
+  expect(creates).toHaveLength(0)
+})
+
+it('should add shared registry cache flags when base is set', async () => {
+  const registry = createRegistry({ base: 'example.com/reg', platforms: ['linux/amd64'] })
+
+  registry.composition(/** @type {any} */ ({}))
+  registry.service('.', /** @type {any} */ ({}))
+
+  await registry.build()
+
+  const builds = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === '--context=default' && args[2] === 'build')
+
+  expect(builds).toHaveLength(2)
+
+  for (const [, args] of builds) {
+    expect(args).toContain('--cache-from')
+    expect(args).toContain('type=registry,ref=example.com/reg/acme/buildcache')
+    expect(args).toContain('--cache-to')
+    expect(args).toContain('type=registry,ref=example.com/reg/acme/buildcache,mode=max,image-manifest=true')
+  }
+})
+
+it('should omit cache flags when base is not set', async () => {
+  const registry = createRegistry({ platforms: ['linux/amd64'] })
+
+  registry.composition(/** @type {any} */ ({}))
+
+  await registry.build()
+
+  const builds = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === '--context=default' && args[2] === 'build')
+
+  expect(builds).toHaveLength(1)
+
+  const [, args] = builds[0]
+
+  expect(args).not.toContain('--cache-from')
+  expect(args).not.toContain('--cache-to')
+})
+
+it('should use default builder when platforms is null', async () => {
+  const registry = createRegistry({ base: 'example.com/reg', platforms: null })
+
+  registry.composition(/** @type {any} */ ({}))
+
+  await registry.build()
+
+  const builds = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === '--context=default' && args[2] === 'build')
+
+  expect(builds).toHaveLength(1)
+
+  const [, args] = builds[0]
+
+  expect(args[args.indexOf('--builder') + 1]).toBe('default')
+  expect(args).not.toContain('--cache-from')
+  expect(args).not.toContain('--platform')
+})
+
+it('should skip build when image already exists', async () => {
+  process.execute = jest.fn(async () => '')
+
+  const registry = createRegistry({ base: 'example.com/reg', platforms: ['linux/amd64'] })
+
+  registry.composition(/** @type {any} */ ({}))
+
+  await registry.build()
+
+  const builds = process.execute.mock.calls.filter(([, args]) =>
+    args[0] === '--context=default' && args[2] === 'build')
+
+  expect(builds).toHaveLength(0)
+  expect(process.execute).toHaveBeenCalledWith('docker', ['manifest', 'inspect', images[0].reference], { silently: true })
+})
+
+/**
+ * @param {object} [registry]
+ * @returns {Registry}
+ */
+function createRegistry (registry = {}) {
+  return new Registry('acme', registry, factory, process)
+}
+
+/**
+ * @param {string} name
+ * @returns {toa.deployment.images.Image}
+ */
+function createImage (name) {
+  const image = /** @type {toa.deployment.images.Image} */ {
+    reference: `example.com/reg/acme/${name}:abcdef12`,
+    context: `/tmp/${name}`,
+    prepare: jest.fn(async () => `/tmp/${name}`)
+  }
+
+  images.push(image)
+
+  return image
+}


### PR DESCRIPTION
## Summary
- Reuse a named buildx builder and shared registry cache so runtime layers are not rebuilt per image
- Publish `ghcr.io/toa-io/runtime:<version>` on release and use it as the default deploy base image
- Drop per-image `npm i -g @toa.io/runtime` from composition/service Dockerfiles

## Test plan
- [ ] Unit: `npx jest operations/src/deployment/registry.test.js operations/src/deployment/images/runtime-base.test.js --roots operations`
- [ ] After merge to `alpha`, confirm release publishes npm packages and pushes `ghcr.io/toa-io/runtime:<version>`
- [ ] Bump `@toa.io/runtime` in a consumer and confirm Deploy pulls the base image (no global runtime install) and is faster on rebuilds


Made with [Cursor](https://cursor.com)