### PR TITLE
feat(operations): soft topology spread for compositions and extensions

### DIFF
--- a/integration/deployment.template.test.js
+++ b/integration/deployment.template.test.js
@@ -58,6 +58,17 @@ describe('compositions', () => {
         expect(labels[component]).toStrictEqual('1')
       }
 
+      expect(deployment.spec.template.spec.topologySpreadConstraints).toStrictEqual([{
+        maxSkew: 1,
+        topologyKey: 'kubernetes.io/hostname',
+        whenUnsatisfiable: 'ScheduleAnyway',
+        labelSelector: {
+          matchLabels: {
+            'toa.io/composition': composition.name
+          }
+        }
+      }])
+
       const container = deployment.spec.template.spec.containers[0]
 
       expect(container.name).toStrictEqual(composition.name)
@@ -114,6 +125,17 @@ describe('services', () => {
       expect(deployment.spec.replicas).toStrictEqual(2)
       expect(deployment.spec.selector.matchLabels['toa.io/service']).toStrictEqual(service.name)
       expect(deployment.spec.template.metadata.labels['toa.io/service']).toStrictEqual(service.name)
+
+      expect(deployment.spec.template.spec.topologySpreadConstraints).toStrictEqual([{
+        maxSkew: 1,
+        topologyKey: 'kubernetes.io/hostname',
+        whenUnsatisfiable: 'ScheduleAnyway',
+        labelSelector: {
+          matchLabels: {
+            'toa.io/service': service.name
+          }
+        }
+      }])
 
       const container = deployment.spec.template.spec.containers[0]
 

--- a/operations/src/deployment/chart/templates/compositions.yaml
+++ b/operations/src/deployment/chart/templates/compositions.yaml
@@ -66,5 +66,12 @@ spec:
             claimName: {{ .claim }}
         {{- end }}
       {{- end }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              toa.io/composition: {{ .name }}
 ---
 {{- end }}

--- a/operations/src/deployment/chart/templates/services.yaml
+++ b/operations/src/deployment/chart/templates/services.yaml
@@ -73,6 +73,13 @@ spec:
               exec:
                 command: [sleep, "5"]
       terminationGracePeriodSeconds: 45
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              toa.io/service: extension-{{ .name }}
 {{- if .port }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary
- Add soft `topologySpreadConstraints` (`ScheduleAnyway`, hostname) to composition and extension Deployments
- Assert the constraint in the deployment template integration test

## Test plan
- [ ] Merge to alpha triggers Release workflow
- [ ] `@toa.io/operations` / `@toa.io/runtime` publish new alpha versions
- [ ] After publish, bump ants.toa via `toa:upgrade` and redeploy


Made with [Cursor](https://cursor.com)