### PR TITLE
fix: settle exposition route discovery before ready

### DIFF
--- a/extensions/exposition/features/probes.feature
+++ b/extensions/exposition/features/probes.feature
@@ -2,7 +2,7 @@ Feature: Probes
 
   Scenario: Startup probe
     Given the Gateway is running
-    And after 1 second
+    And after 5 seconds
     When the following request is received:
       """
       GET /.ready HTTP/1.1

--- a/extensions/exposition/source/Gateway.ts
+++ b/extensions/exposition/source/Gateway.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert'
+import { setTimeout } from 'node:timers/promises'
 import { console } from 'openspan'
 import { type bindings, Connector } from '@toa.io/core'
 import * as http from './HTTP'
@@ -13,6 +14,8 @@ export class Gateway extends Connector {
   private readonly tree: Tree
   private readonly interceptor: Interception
   private readonly merged = new Set<string>()
+  private lastMerge = 0
+  private resolveFirstMerge: (() => void) | null = null
 
   public constructor (broadcast: Broadcast, tree: Tree, interception: Interception) {
     super()
@@ -119,8 +122,32 @@ export class Gateway extends Connector {
   }
 
   private async discover (): Promise<void> {
+    const first = new Promise<void>((resolve) => {
+      this.resolveFirstMerge = resolve
+    })
+
     await this.broadcast.receive<Branch>('expose', this.merge.bind(this))
     await this.broadcast.transmit<null>('ping', null)
+    await this.settled(first)
+  }
+
+  private async settled (first: Promise<void>): Promise<void> {
+    const deadline = Date.now() + SETTLE_TIMEOUT
+
+    await Promise.race([first, setTimeout(SETTLE_TIMEOUT)])
+
+    if (this.lastMerge === 0) {
+      console.warn('Discovery timed out waiting for the first expose')
+
+      return
+    }
+
+    while (Date.now() - this.lastMerge < SETTLE_QUIET) {
+      if (Date.now() >= deadline)
+        break
+
+      await setTimeout(SETTLE_POLL)
+    }
   }
 
   private merge (branch: Branch): void {
@@ -136,8 +163,6 @@ export class Gateway extends Connector {
       return
     }
 
-    this.merged.add(id)
-
     const attributes = {
       namespace: branch.namespace,
       component: branch.component,
@@ -146,14 +171,25 @@ export class Gateway extends Connector {
 
     try {
       this.tree.merge(branch.node, branch)
-
-      console.info('Branch merged', attributes)
     } catch (exception: unknown) {
       const message = exception instanceof Error ? exception.message : 'Unknown error'
 
       console.error('Branch merge exception', { message, ...attributes })
+
+      return
     }
+
+    this.merged.add(id)
+    this.lastMerge = Date.now()
+    this.resolveFirstMerge?.()
+    this.resolveFirstMerge = null
+
+    console.info('Branch merged', attributes)
   }
 }
 
 export type Broadcast = bindings.Broadcast<Label>
+
+const SETTLE_QUIET = 1000
+const SETTLE_TIMEOUT = 30_000
+const SETTLE_POLL = 50

--- a/libraries/agent/source/Agent.ts
+++ b/libraries/agent/source/Agent.ts
@@ -52,20 +52,25 @@ export class Agent {
 
     const protocol = new URL(req.url).protocol === 'https:' ? https : http
 
-    const response = await new Promise<http.IncomingMessage>((resolve) => {
+    const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
       const request = protocol.request(req.url, {
         method: req.method,
         headers
       }, (response) => resolve(response))
 
+      request.on('error', reject)
       request.end(req.body)
     })
 
-    assert.ok(response.statusCode === 200 || response.statusCode === 201,
-      `Request failed with status ${response.statusCode}: ${req.url}`)
+    if (response.statusCode !== 200 && response.statusCode !== 201) {
+      response.destroy()
+
+      assert.fail(`Request failed with status ${response.statusCode}: ${req.url}`)
+    }
 
     this.pending.add(response)
     response.on('end', () => this.pending.delete(response))
+    response.on('error', () => this.pending.delete(response))
 
     return await meros(response)
   }


### PR DESCRIPTION
## Summary
- Wait for the first `expose` after gateway `ping`, then 1s of merge quiet, so `/.ready` (and k8s startup/readiness probes) stay 503 until the resource tree has begun merging — fixes flaky post-deploy `Route not found` 404s.
- Destroy failed multipart responses in `@toa.io/agent` `parts()` to avoid later uncaught `ECONNRESET`.

## Test plan
- [x] `npm run features -- features/probes.feature` in `extensions/exposition`
- [ ] ants.toa production features after alpha publish/deploy


Made with [Cursor](https://cursor.com)