### PR TITLE
fix: converge exposition route discovery across gateway replicas

### DIFF
--- a/connectors/bindings.amqp/source/broadcast.js
+++ b/connectors/bindings.amqp/source/broadcast.js
@@ -30,7 +30,7 @@ class Broadcast extends Connector {
   async transmit (label, payload) {
     const exchange = name(this.#locator, label)
 
-    await this.#comm.emit(exchange, payload, { deliveryMode: 1, expiration: 1000 })
+    await this.#comm.emit(exchange, payload, { deliveryMode: 1 })
   }
 
   async receive (label, callback) {

--- a/connectors/bindings.amqp/test/broadcast.test.js
+++ b/connectors/bindings.amqp/test/broadcast.test.js
@@ -52,8 +52,7 @@ it('should transmit', async () => {
   const exchange = mock.queues.name.mock.results[0].value
 
   expect(comm.emit).toHaveBeenCalledWith(exchange, message, {
-    'deliveryMode': 1,
-    'expiration': 1000
+    'deliveryMode': 1
   })
 })
 

--- a/extensions/exposition/features/dynamic.feature
+++ b/extensions/exposition/features/dynamic.feature
@@ -83,7 +83,43 @@ Feature: Dynamic tree updates
       200 OK
       """
 
+  Scenario: Stale branch expires
+    Given the branch TTL is 0.5 seconds
+    And the Gateway is running
+    And the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          io:output: true
+          GET: enumerate
+      """
+    When the following request is received:
+      """
+      GET /pots/ HTTP/1.1
+      host: nex.toa.io
+      accept: application/yaml
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      """
+    Then the `pots` is stopped
+    And after 0.8 seconds
+    When the following request is received:
+      """
+      GET /pots/ HTTP/1.1
+      host: nex.toa.io
+      accept: text/plain
+      """
+    Then the following reply is sent:
+      """
+      404 Not Found
+
+      Route not found
+      """
+
   Scenario: Updating routes with conflict
+    Given the Gateway is running
     And the `pots` is running with the following manifest:
       """yaml
       version: 1.0.0
@@ -119,7 +155,8 @@ Feature: Dynamic tree updates
       """
 
   Scenario: Updating method mapping
-    Given the `pots` is running with the following manifest:
+    Given the Gateway is running
+    And the `pots` is running with the following manifest:
       """yaml
       version: a
       exposition:

--- a/extensions/exposition/features/probes.feature
+++ b/extensions/exposition/features/probes.feature
@@ -2,7 +2,7 @@ Feature: Probes
 
   Scenario: Startup probe
     Given the Gateway is running
-    And after 5 seconds
+    And after 15 seconds
     When the following request is received:
       """
       GET /.ready HTTP/1.1

--- a/extensions/exposition/features/steps/Gateway.ts
+++ b/extensions/exposition/features/steps/Gateway.ts
@@ -58,6 +58,15 @@ export class Gateway {
     this.default = false
   }
 
+  @given('the branch TTL is {float} second(s)')
+  public async setBranchTTL (seconds: number): Promise<void> {
+    process.env.__TESTING_EXPOSITION_BRANCH_TTL = String(seconds * 1000)
+
+    await Gateway.stop()
+
+    this.default = false
+  }
+
   @given('the Gateway is running')
   public async start (): Promise<void> {
     if (instance !== null)
@@ -82,6 +91,8 @@ export class Gateway {
 
   @after()
   public async cleanup (): Promise<void> {
+    delete process.env.__TESTING_EXPOSITION_BRANCH_TTL
+
     if (this.default)
       return
 

--- a/extensions/exposition/source/Gateway.ts
+++ b/extensions/exposition/source/Gateway.ts
@@ -153,16 +153,6 @@ export class Gateway extends Connector {
   private merge (branch: Branch): void {
     const id = branch.namespace + '.' + branch.component + '@' + branch.version
 
-    if (this.merged.has(id)) {
-      console.debug('Branch already merged, ignoring', {
-        namespace: branch.namespace,
-        component: branch.component,
-        version: branch.version
-      })
-
-      return
-    }
-
     const attributes = {
       namespace: branch.namespace,
       component: branch.component,
@@ -175,6 +165,12 @@ export class Gateway extends Connector {
       const message = exception instanceof Error ? exception.message : 'Unknown error'
 
       console.error('Branch merge exception', { message, ...attributes })
+
+      return
+    }
+
+    if (this.merged.has(id)) {
+      console.debug('Branch refreshed', attributes)
 
       return
     }

--- a/extensions/exposition/source/Gateway.ts
+++ b/extensions/exposition/source/Gateway.ts
@@ -190,6 +190,6 @@ export class Gateway extends Connector {
 
 export type Broadcast = bindings.Broadcast<Label>
 
-const SETTLE_QUIET = 1000
+const SETTLE_QUIET = 10_000
 const SETTLE_TIMEOUT = 30_000
 const SETTLE_POLL = 50

--- a/extensions/exposition/source/RTD/Node.ts
+++ b/extensions/exposition/source/RTD/Node.ts
@@ -5,6 +5,7 @@ import { type Match, type Parameter } from './Match'
 export class Node {
   public intermediate: boolean
   public forward: string | null
+  public expiration: number
   public methods: Methods
   private readonly protected: boolean
   private routes: Route[]
@@ -14,6 +15,7 @@ export class Node {
     this.methods = methods
     this.protected = properties.protected
     this.forward = properties.forward ?? null
+    this.expiration = properties.expiration ?? Infinity
     this.intermediate = this.routes.findIndex((route) => route.root) !== -1
 
     this.sort()
@@ -59,6 +61,8 @@ export class Node {
 
     this.routes = node.routes
     this.methods = node.methods
+    this.expiration = node.expiration
+    this.forward = node.forward
 
     // race condition is really unlikely
     for (const method of methods)
@@ -96,4 +100,5 @@ export class Node {
 export interface Properties {
   protected: boolean
   forward?: string
+  expiration?: number
 }

--- a/extensions/exposition/source/RTD/Route.ts
+++ b/extensions/exposition/source/RTD/Route.ts
@@ -22,6 +22,9 @@ export class Route {
   }
 
   public match (fragments: string[], parameters: Parameter[]): Match | null {
+    if (Date.now() >= this.node.expiration)
+      return null
+
     for (let i = 0; i < this.segments.length; i++) {
       const segment = this.segments[i]
 

--- a/extensions/exposition/source/RTD/Tree.ts
+++ b/extensions/exposition/source/RTD/Tree.ts
@@ -16,8 +16,8 @@ export class Tree {
   public constructor (node: syntax.Node, endpoints: EndpointsFactory, directives: DirectiveFactory) {
     this.endpoints = endpoints
     this.directives = directives
-    this.trunk = this.createNode(node, PROTECTED)
     this.root = node
+    this.trunk = this.createNode(node, PROTECTED)
   }
 
   public match (path: string): Match | null {
@@ -48,7 +48,7 @@ export class Tree {
       endpoints: this.endpoints,
       directives: {
         factory: this.directives,
-        stack: this.root?.directives ?? []
+        stack: this.root.directives ?? []
       },
       extension
     }

--- a/extensions/exposition/source/RTD/expiration.test.ts
+++ b/extensions/exposition/source/RTD/expiration.test.ts
@@ -1,0 +1,54 @@
+import { Tree } from './Tree'
+import type { EndpointsFactory } from '../Endpoint'
+import type { DirectiveFactory } from './Directives'
+import type * as syntax from './syntax'
+
+const endpoints = {} as unknown as EndpointsFactory
+
+const directives = {
+  create: () => ({
+    preflight: async () => null,
+    settle: async () => undefined,
+    dispose: () => undefined
+  }),
+  dispose: jest.fn()
+} as unknown as DirectiveFactory
+
+const root: syntax.Node = {
+  routes: [],
+  methods: [],
+  directives: []
+}
+
+const pots: syntax.Node = {
+  routes: [
+    {
+      path: '/pots',
+      node: {
+        routes: [],
+        methods: [{ verb: 'GET', directives: [] }],
+        directives: []
+      }
+    }
+  ],
+  methods: [],
+  directives: []
+}
+
+it('should ignore expired nodes during match', () => {
+  process.env.__TESTING_EXPOSITION_BRANCH_TTL = '1000'
+
+  const now = jest.spyOn(Date, 'now').mockReturnValue(10_000)
+  const tree = new Tree(root, endpoints, directives)
+
+  tree.merge(pots, { namespace: 'default', component: 'pots' })
+
+  expect(tree.match('/pots/')).not.toBeNull()
+
+  now.mockReturnValue(11_000)
+
+  expect(tree.match('/pots/')).toBeNull()
+
+  now.mockRestore()
+  delete process.env.__TESTING_EXPOSITION_BRANCH_TTL
+})

--- a/extensions/exposition/source/RTD/factory.ts
+++ b/extensions/exposition/source/RTD/factory.ts
@@ -1,3 +1,4 @@
+import { BRANCH_TTL } from '../const'
 import { Node, type Properties } from './Node'
 import { Route } from './Route'
 import { segment } from './segment'
@@ -17,12 +18,26 @@ export function createNode (node: syntax.Node, context: Context): Node {
   for (const method of node.methods)
     methods[method.verb] = createMethod(method, context)
 
+  const protect = node.protected ?? context.protected
+
   const properties: Properties = {
-    protected: node.protected ?? context.protected,
-    forward: node.forward
+    protected: protect,
+    forward: node.forward,
+    expiration: protect ? Infinity : Date.now() + branchTTL()
   }
 
   return new Node(routes, methods, properties)
+}
+
+function branchTTL (): number {
+  const value = process.env.__TESTING_EXPOSITION_BRANCH_TTL
+
+  if (value === undefined || value === '')
+    return BRANCH_TTL
+
+  const parsed = Number(value)
+
+  return Number.isFinite(parsed) ? parsed : BRANCH_TTL
 }
 
 function createRoute (route: syntax.Route, context: Context): Route {

--- a/extensions/exposition/source/Tenant.ts
+++ b/extensions/exposition/source/Tenant.ts
@@ -1,4 +1,6 @@
+import { setTimeout } from 'node:timers/promises'
 import { Connector } from '@toa.io/core'
+import { BRANCH_TTL } from './const'
 import type { bindings } from '@toa.io/core'
 import type { Label } from './discovery'
 import type { Branch } from './Branch'
@@ -6,6 +8,8 @@ import type { Branch } from './Branch'
 export class Tenant extends Connector {
   private readonly broadcast: Broadcast
   private readonly branch: Branch
+  private started = 0
+  private stopped = false
 
   public constructor (broadcast: Broadcast, branch: Branch) {
     super()
@@ -17,13 +21,42 @@ export class Tenant extends Connector {
   }
 
   public override async open (): Promise<void> {
+    this.started = Date.now()
+
     await this.expose()
     await this.broadcast.receive('ping', this.expose.bind(this))
+
+    void this.announce()
+  }
+
+  protected override dispose (): void {
+    this.stopped = true
+  }
+
+  private async announce (): Promise<void> {
+    while (!this.stopped) {
+      const delay = exposeInterval(Date.now() - this.started)
+
+      await setTimeout(delay, undefined, { ref: false })
+
+      if (this.stopped)
+        break
+
+      await this.expose()
+    }
   }
 
   private async expose (): Promise<void> {
     await this.broadcast.transmit('expose', this.branch)
   }
 }
+
+function exposeInterval (uptime: number): number {
+  return Math.round(EXPOSE_MAX - (EXPOSE_MAX - EXPOSE_MIN) * Math.exp(-uptime / EXPOSE_TAU))
+}
+
+const EXPOSE_MIN = 5_000
+const EXPOSE_MAX = Math.round(BRANCH_TTL / 2.1)
+const EXPOSE_TAU = 900_000
 
 type Broadcast = bindings.Broadcast<Label>

--- a/extensions/exposition/source/const.ts
+++ b/extensions/exposition/source/const.ts
@@ -1,0 +1,1 @@
+export const BRANCH_TTL = 1_800_000


### PR DESCRIPTION
## Summary
- Drop AMQP broadcast message TTL so late `expose`/`ping` survive gateway rollout.
- Raise exposition merge quiet to 10s before `/.ready` (covers ~9s inter-composition gaps).
- Tenants periodically re-expose with exponential backoff (capped below branch TTL); route nodes carry `expiration` so stale branches stop matching without gateway prune timers.

## Test plan
- [x] `npx jest --roots connectors --testPathPatterns=bindings.amqp/test/broadcast`
- [x] `npm run features -- features/probes.feature` in `extensions/exposition`
- [x] `npx jest --testPathPatterns=expiration` in `extensions/exposition`
- [x] `npm run features -- features/dynamic.feature` in `extensions/exposition`