### PR TITLE
fix(exposition): keep endpoints alive across branch refreshes

### DIFF
--- a/connectors/bindings.amqp/package.json
+++ b/connectors/bindings.amqp/package.json
@@ -20,7 +20,7 @@
     "@toa.io/core": "1.0.0-alpha.239",
     "@toa.io/generic": "1.0.0-alpha.225",
     "@toa.io/pointer": "1.0.0-alpha.225",
-    "comq": "0.15.1",
+    "comq": "0.15.2",
     "openspan": "1.0.0-alpha.173"
   },
   "scripts": {

--- a/connectors/bindings.amqp/source/communication.js
+++ b/connectors/bindings.amqp/source/communication.js
@@ -2,6 +2,7 @@
 
 const { assert } = require('comq')
 const { Connector } = require('@toa.io/core')
+const { console } = require('openspan')
 
 class Communication extends Connector {
   #resolve
@@ -19,6 +20,8 @@ class Communication extends Connector {
     const references = await this.#resolve()
 
     this.#io = await assert(...references)
+
+    this.#diagnose()
   }
 
   async close () {
@@ -51,6 +54,50 @@ class Communication extends Connector {
 
   async enqueue (queue, message) {
     await this.#io.enqueue(queue, message)
+  }
+
+  /**
+   * Without this, an undeliverable message, a discarded request or a shard
+   * dropping out leave no trace at all.
+   */
+  #diagnose () {
+    this.#io.diagnose('return', (type, message, shard) =>
+      console.error('AMQP message returned', {
+        type,
+        queue: message.fields?.routingKey,
+        correlationId: message.properties?.correlationId,
+        shard
+      }))
+
+    this.#io.diagnose('discard', (type, message, exception, shard) =>
+      console.error('AMQP message discarded', {
+        type,
+        queue: message.fields?.routingKey,
+        message: exception?.message,
+        shard
+      }))
+
+    this.#io.diagnose('remove', (type, shard) =>
+      console.warn('AMQP shard removed', { type, shard }))
+
+    this.#io.diagnose('recover', (type, shard) =>
+      console.info('AMQP channel recovered', { type, shard }))
+
+    this.#io.diagnose('flow', (type, shard) =>
+      console.warn('AMQP back pressure', { type, shard }))
+
+    this.#io.diagnose('drain', (type, shard) =>
+      console.info('AMQP back pressure released', { type, shard }))
+
+    this.#io.diagnose('close', (error, shard) => {
+      if (error === undefined)
+        console.debug('AMQP connection closed', { shard })
+      else
+        console.warn('AMQP connection lost', { message: error.message, shard })
+    })
+
+    this.#io.diagnose('open', (shard) =>
+      console.debug('AMQP connection open', { shard }))
   }
 }
 

--- a/extensions/exposition/source/Gateway.ts
+++ b/extensions/exposition/source/Gateway.ts
@@ -5,7 +5,7 @@ import { type bindings, Connector } from '@toa.io/core'
 import * as http from './HTTP'
 import { rethrow } from './exceptions'
 import type { Interception } from './Interception'
-import type { Node, Method, Parameter, Tree, Match } from './RTD'
+import type { Method, Node, Parameter, Tree, Match } from './RTD'
 import type { Label } from './discovery'
 import type { Branch } from './Branch'
 
@@ -13,8 +13,11 @@ export class Gateway extends Connector {
   private readonly broadcast: Broadcast
   private readonly tree: Tree
   private readonly interceptor: Interception
-  private readonly merged = new Set<string>()
+  private readonly branches = new Map<string, Exposed>()
   private lastMerge = 0
+  private lastPing = 0
+  private stopped = false
+  private reconciliation: NodeJS.Timeout | null = null
   private resolveFirstMerge: (() => void) | null = null
 
   public constructor (broadcast: Broadcast, tree: Tree, interception: Interception) {
@@ -68,6 +71,11 @@ export class Gateway extends Connector {
   }
 
   protected override dispose (): void {
+    this.stopped = true
+
+    if (this.reconciliation !== null)
+      clearInterval(this.reconciliation)
+
     this.tree.dispose()
 
     console.info('Gateway is closed')
@@ -76,8 +84,12 @@ export class Gateway extends Connector {
   private match (context: http.Context): Match {
     const match = this.tree.match(context.url.pathname)
 
-    if (match === null)
+    if (match === null) {
+      // the route may be missing because an expose has been lost
+      this.reping()
+
       throw new http.NotFound('Route not found')
+    }
 
     if (match.node.forward === null)
       return match
@@ -127,8 +139,47 @@ export class Gateway extends Connector {
     })
 
     await this.broadcast.receive<Branch>('expose', this.merge.bind(this))
-    await this.broadcast.transmit<null>('ping', null)
+
+    void this.knock()
+
     await this.settled(first)
+
+    this.reconciliation = setInterval(() => void this.ping(), RECONCILE_INTERVAL)
+    this.reconciliation.unref()
+  }
+
+  /**
+   * A single ping is enough only if every tenant is listening by then, which is
+   * not the case while the deployment is still rolling out.
+   */
+  private async knock (): Promise<void> {
+    for (const delay of KNOCK_DELAYS) {
+      if (this.stopped)
+        return
+
+      if (delay > 0)
+        await setTimeout(delay, undefined, { ref: false })
+
+      await this.ping()
+    }
+  }
+
+  private async ping (): Promise<void> {
+    if (this.stopped)
+      return
+
+    this.lastPing = Date.now()
+
+    await this.broadcast.transmit<null>('ping', null)
+      .catch((exception: Error) => console.error('Discovery ping failed',
+        { message: exception.message }))
+  }
+
+  private reping (): void {
+    if (Date.now() - this.lastPing < PING_COOLDOWN)
+      return
+
+    void this.ping()
   }
 
   private async settled (first: Promise<void>): Promise<void> {
@@ -151,7 +202,7 @@ export class Gateway extends Connector {
   }
 
   private merge (branch: Branch): void {
-    const id = branch.namespace + '.' + branch.component + '@' + branch.version
+    const id = branch.namespace + '.' + branch.component
 
     const attributes = {
       namespace: branch.namespace,
@@ -159,8 +210,20 @@ export class Gateway extends Connector {
       version: branch.version
     }
 
+    const exposed = this.branches.get(id)
+
+    // rebuilding an identical branch would only tear down its live endpoints
+    if (exposed?.version === branch.version) {
+      this.tree.refresh(exposed.nodes)
+      console.debug('Branch refreshed', attributes)
+
+      return
+    }
+
+    let nodes: Node[]
+
     try {
-      this.tree.merge(branch.node, branch)
+      nodes = this.tree.merge(branch.node, branch)
     } catch (exception: unknown) {
       const message = exception instanceof Error ? exception.message : 'Unknown error'
 
@@ -169,13 +232,7 @@ export class Gateway extends Connector {
       return
     }
 
-    if (this.merged.has(id)) {
-      console.debug('Branch refreshed', attributes)
-
-      return
-    }
-
-    this.merged.add(id)
+    this.branches.set(id, { version: branch.version, nodes })
     this.lastMerge = Date.now()
     this.resolveFirstMerge?.()
     this.resolveFirstMerge = null
@@ -186,6 +243,14 @@ export class Gateway extends Connector {
 
 export type Broadcast = bindings.Broadcast<Label>
 
+interface Exposed {
+  version: string
+  nodes: Node[]
+}
+
 const SETTLE_QUIET = 10_000
 const SETTLE_TIMEOUT = 30_000
 const SETTLE_POLL = 50
+const KNOCK_DELAYS = [0, 500, 1000, 1500]
+const RECONCILE_INTERVAL = 30_000
+const PING_COOLDOWN = 5_000

--- a/extensions/exposition/source/RTD/Node.ts
+++ b/extensions/exposition/source/RTD/Node.ts
@@ -33,15 +33,28 @@ export class Node {
     return null
   }
 
-  public merge (node: Node): void {
+  /**
+   * Returns the nodes the merged branch has landed on, so that its expiration
+   * can later be extended without rebuilding anything.
+   */
+  public merge (node: Node): Node[] {
     this.intermediate = node.intermediate
 
-    if (this.protected)
-      this.append(node)
-    else
-      this.replace(node)
+    const nodes = this.protected ? this.append(node) : this.replace(node)
 
     this.sort()
+
+    return nodes
+  }
+
+  public touch (expiration: number): void {
+    if (this.protected)
+      return
+
+    this.expiration = expiration
+
+    for (const route of this.routes)
+      route.node.touch(expiration)
   }
 
   public async explain (parameters: Parameter[]): Promise<Record<string, unknown>> {
@@ -56,7 +69,7 @@ export class Node {
     return methods
   }
 
-  private replace (node: Node): void {
+  private replace (node: Node): Node[] {
     const methods = Object.values(this.methods)
 
     this.routes = node.routes
@@ -67,25 +80,30 @@ export class Node {
     // race condition is really unlikely
     for (const method of methods)
       void method.close()
+
+    return [this]
   }
 
-  private append (node: Node): void {
+  private append (node: Node): Node[] {
+    const nodes: Node[] = []
+
     for (const route of node.routes)
-      this.route(route)
+      nodes.push(...this.route(route))
 
     for (const [verb, method] of Object.entries(node.methods))
       this.methods[verb] = method
+
+    return nodes
   }
 
-  private route (candidate: Route): void {
+  private route (candidate: Route): Node[] {
     for (const route of this.routes)
-      if (candidate.equals(route)) {
-        route.merge(candidate)
-
-        return
-      }
+      if (candidate.equals(route))
+        return route.merge(candidate)
 
     this.routes.push(candidate)
+
+    return [candidate.node]
   }
 
   private sort (): void {

--- a/extensions/exposition/source/RTD/Node.ts
+++ b/extensions/exposition/source/RTD/Node.ts
@@ -48,13 +48,8 @@ export class Node {
   }
 
   public touch (expiration: number): void {
-    if (this.protected)
-      return
-
-    this.expiration = expiration
-
-    for (const route of this.routes)
-      route.node.touch(expiration)
+    if (!this.protected)
+      this.expiration = expiration
   }
 
   public async explain (parameters: Parameter[]): Promise<Record<string, unknown>> {
@@ -81,7 +76,7 @@ export class Node {
     for (const method of methods)
       void method.close()
 
-    return [this]
+    return this.nodes()
   }
 
   private append (node: Node): Node[] {
@@ -103,7 +98,16 @@ export class Node {
 
     this.routes.push(candidate)
 
-    return [candidate.node]
+    return candidate.node.nodes()
+  }
+
+  private nodes (): Node[] {
+    const nodes: Node[] = [this]
+
+    for (const route of this.routes)
+      nodes.push(...route.node.nodes())
+
+    return nodes
   }
 
   private sort (): void {

--- a/extensions/exposition/source/RTD/Route.ts
+++ b/extensions/exposition/source/RTD/Route.ts
@@ -1,12 +1,12 @@
-import { type Node } from './Node'
 import { type Segment } from './segment'
 import { type Match, type Parameter } from './Match'
+import type { Node } from './Node'
 
 export class Route {
   public readonly root: boolean
   public readonly variables: number = 0
   public readonly segments: Segment[]
-  private readonly node: Node
+  public readonly node: Node
   private readonly wildcard: boolean = false
 
   public constructor (segments: Segment[], node: Node) {
@@ -57,8 +57,8 @@ export class Route {
     return true
   }
 
-  public merge (route: Route): void {
-    this.node.merge(route.node)
+  public merge (route: Route): Node[] {
+    return this.node.merge(route.node)
   }
 
   private matchNested (fragments: string[], parameters: Parameter[]): Match | null {

--- a/extensions/exposition/source/RTD/Tree.ts
+++ b/extensions/exposition/source/RTD/Tree.ts
@@ -1,4 +1,4 @@
-import { createNode } from './factory'
+import { branchTTL, createNode } from './factory'
 import { fragment } from './segment'
 import type { Node } from './Node'
 import type { Match } from './Match'
@@ -32,10 +32,21 @@ export class Tree {
     return this.trunk.match(fragments)
   }
 
-  public merge (node: syntax.Node, extension: unknown): void {
+  public merge (node: syntax.Node, extension: unknown): Node[] {
     const branch = this.createNode(node, !PROTECTED, extension)
 
-    this.trunk.merge(branch)
+    return this.trunk.merge(branch)
+  }
+
+  /**
+   * Extends the expiration of an already merged branch, leaving its endpoints
+   * and their remotes intact.
+   */
+  public refresh (nodes: Node[]): void {
+    const expiration = Date.now() + branchTTL()
+
+    for (const node of nodes)
+      node.touch(expiration)
   }
 
   public dispose (): void {

--- a/extensions/exposition/source/RTD/expiration.test.ts
+++ b/extensions/exposition/source/RTD/expiration.test.ts
@@ -35,6 +35,30 @@ const pots: syntax.Node = {
   directives: []
 }
 
+it('should extend expiration without rebuilding the branch', () => {
+  process.env.__TESTING_EXPOSITION_BRANCH_TTL = '1000'
+
+  const now = jest.spyOn(Date, 'now').mockReturnValue(10_000)
+  const tree = new Tree(root, endpoints, directives)
+  const nodes = tree.merge(pots, { namespace: 'default', component: 'pots' })
+  const match = tree.match('/pots/')
+
+  expect(match).not.toBeNull()
+
+  now.mockReturnValue(10_900)
+  tree.refresh(nodes)
+
+  now.mockReturnValue(11_500)
+
+  const refreshed = tree.match('/pots/')
+
+  expect(refreshed).not.toBeNull()
+  expect(refreshed?.node).toBe(match?.node)
+
+  now.mockRestore()
+  delete process.env.__TESTING_EXPOSITION_BRANCH_TTL
+})
+
 it('should ignore expired nodes during match', () => {
   process.env.__TESTING_EXPOSITION_BRANCH_TTL = '1000'
 

--- a/extensions/exposition/source/RTD/factory.ts
+++ b/extensions/exposition/source/RTD/factory.ts
@@ -29,7 +29,7 @@ export function createNode (node: syntax.Node, context: Context): Node {
   return new Node(routes, methods, properties)
 }
 
-function branchTTL (): number {
+export function branchTTL (): number {
   const value = process.env.__TESTING_EXPOSITION_BRANCH_TTL
 
   if (value === undefined || value === '')

--- a/extensions/exposition/source/Tenant.ts
+++ b/extensions/exposition/source/Tenant.ts
@@ -1,6 +1,5 @@
 import { setTimeout } from 'node:timers/promises'
 import { Connector } from '@toa.io/core'
-import { BRANCH_TTL } from './const'
 import type { bindings } from '@toa.io/core'
 import type { Label } from './discovery'
 import type { Branch } from './Branch'
@@ -56,7 +55,9 @@ function exposeInterval (uptime: number): number {
 }
 
 const EXPOSE_MIN = 5_000
-const EXPOSE_MAX = Math.round(BRANCH_TTL / 2.1)
+
+// a refresh no longer rebuilds the branch, so exposing often is cheap
+const EXPOSE_MAX = 120_000
 const EXPOSE_TAU = 900_000
 
 type Broadcast = bindings.Broadcast<Label>

--- a/extensions/origins/package.json
+++ b/extensions/origins/package.json
@@ -22,7 +22,7 @@
     "@toa.io/generic": "1.0.0-alpha.225",
     "@toa.io/pointer": "1.0.0-alpha.225",
     "@toa.io/schemas": "1.0.0-alpha.225",
-    "comq": "0.15.1",
+    "comq": "0.15.2",
     "msgpackr": "2.0.1",
     "openspan": "1.0.0-alpha.173"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16429,9 +16429,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "@toa.io/core": "1.0.0-alpha.239",
         "@toa.io/generic": "1.0.0-alpha.225",
         "@toa.io/pointer": "1.0.0-alpha.225",
-        "comq": "0.15.1",
+        "comq": "0.15.2",
         "openspan": "1.0.0-alpha.173"
       }
     },
@@ -349,7 +349,7 @@
         "@toa.io/generic": "1.0.0-alpha.225",
         "@toa.io/pointer": "1.0.0-alpha.225",
         "@toa.io/schemas": "1.0.0-alpha.225",
-        "comq": "0.15.1",
+        "comq": "0.15.2",
         "msgpackr": "2.0.1",
         "openspan": "1.0.0-alpha.173"
       }
@@ -11552,9 +11552,9 @@
       }
     },
     "node_modules/comq": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/comq/-/comq-0.15.1.tgz",
-      "integrity": "sha512-62BlW61DrxzLyzA2posNOIDEvjZS4hdWstLNkE701ZlFNq4WirW3ZbtNFlvqRXq9vZHV5eJzvoBkTsTfSQvytA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/comq/-/comq-0.15.2.tgz",
+      "integrity": "sha512-pH5B5ljEYfHSLUUNecuZrW+D/awT/LGE2X+gPMYZH4UJAenLFLP2veQztSHW1rEGQAHipgUtDH5yrsrWLGAYtg==",
       "license": "MIT",
       "dependencies": {
         "amqplib": "^2.0.1",


### PR DESCRIPTION
Fixes the 504s (streamed replies lost with no failure signal) and the slow-healing 404s (replicas serving an incomplete route tree).

Consumes comq 0.15.2, which reports and recovers undeliverable replies and completes sharded subscriptions on every shard.

**exposition**
- `Gateway` tracks the exposed version of each branch and skips `tree.merge` when it is unchanged, extending node expirations through `Tree.refresh` / `Node.touch` instead. A re-expose no longer closes methods or disconnects the remotes behind them.
- discovery is now eager: several knocks while the rollout settles, a 30s reconciliation ping, and a rate-limited ping when `match` raises `NotFound`.
- `Tenant` re-exposes every two minutes instead of every fourteen, which refreshes are now cheap enough to afford.

**bindings.amqp**
- `Communication` wires `io.diagnose`, so returned messages, discarded requests, shard removals and back pressure are logged rather than invisible.

Made with [Cursor](https://cursor.com)