### PR TITLE
fix(operations): keep every replica available during a service rollout

### DIFF
--- a/features/deployment/templates/services.feature
+++ b/features/deployment/templates/services.feature
@@ -92,7 +92,7 @@ Feature: Service Deployment
         failureThreshold: 3
       """
 
-  Scenario: Replicas are replaced in parallel
+  Scenario: Replicas are replaced without reducing availability
     Given I have a component `exposed.one`
     And I have a context with:
       """yaml
@@ -113,7 +113,7 @@ Feature: Service Deployment
       """
       type: RollingUpdate
       rollingUpdate:
-        maxUnavailable: 50%
+        maxUnavailable: 0
         maxSurge: 50%
       """
     And extension-exposition-gateway Deployment spec spec should contain:

--- a/operations/src/deployment/chart/templates/services.yaml
+++ b/operations/src/deployment/chart/templates/services.yaml
@@ -11,7 +11,9 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 50%
+      # a replacement must pass readiness before a running replica is taken out,
+      # otherwise a single pod serves all traffic while the others start up
+      maxUnavailable: 0
       maxSurge: 50%
   selector:
     matchLabels:


### PR DESCRIPTION
Extension services overrode the rolling update strategy with `maxUnavailable: 50%`. For the usual two replicas that rounds to 1, so Kubernetes may drop to a single pod immediately and, since surge allows a third, bring both replacements up simultaneously.

Observed in production: both gateway pods and both `realtime-streams` pods were created at the same instant and took 89s to pass readiness, leaving one pod serving all traffic for that window. Gateway readiness waits for discovery to settle, so this window is inherently long.

Compositions never set a strategy and inherit the Kubernetes 25% default, which rounds to `maxUnavailable: 0` for two replicas and already rolls one pod at a time. This aligns extension services with that behaviour.

Made with [Cursor](https://cursor.com)