### PR TITLE
fix(exposition): accept hash if-none-match on versioned resources

### DIFF
--- a/extensions/exposition/features/etag.feature
+++ b/extensions/exposition/features/etag.feature
@@ -185,6 +185,45 @@ Feature: Optimistic concurrency control
       etag: "2"
       """
 
+  Scenario: Hash `if-none-match` on versioned resource
+    Given the `pots` is running with the following manifest:
+      """yaml
+      exposition:
+        /:
+          io:output: true
+          POST: create
+          /:id:
+            GET: observe
+      """
+    When the following request is received:
+      """
+      POST /pots/ HTTP/1.1
+      host: nex.toa.io
+      accept: application/yaml
+      content-type: application/yaml
+
+      title: Hello
+      volume: 1.5
+      """
+    Then the following reply is sent:
+      """
+      201 Created
+      etag: "1"
+
+      id: ${{ id }}
+      """
+    When the following request is received:
+      """
+      GET /pots/${{ id }}/ HTTP/1.1
+      host: nex.toa.io
+      if-none-match: "ef4a2abb4c896c06d0ab3037427e6c7c3e9a32a0c982eee2df68679babd96da3"
+      """
+    Then the following reply is sent:
+      """
+      200 OK
+      etag: "1"
+      """
+
   Scenario: Unexpected `if-match` format
     Given the `pots` is running with the following manifest:
       """yaml

--- a/extensions/exposition/source/Endpoint.ts
+++ b/extensions/exposition/source/Endpoint.ts
@@ -107,16 +107,17 @@ export class Endpoint implements RTD.Endpoint {
     message.headers ??= new Headers()
 
     if (typeof reply === 'object' && reply !== null && '_version' in reply) {
+      const version = reply._version as number
       const matched = etag === undefined ? null : this.matchVersion(etag)
 
-      if (etag !== undefined && matched !== null && reply._version === matched) {
+      if (etag !== undefined && matched !== null && version === matched) {
         message.status = 304
         message.headers.set('etag', etag)
 
         return true
       }
 
-      message.headers.set('etag', `"${reply._version.toString()}"`)
+      message.headers.set('etag', `"${version.toString()}"`)
 
       return false
     }

--- a/extensions/exposition/source/Endpoint.ts
+++ b/extensions/exposition/source/Endpoint.ts
@@ -45,27 +45,8 @@ export class Endpoint implements RTD.Endpoint {
     if (reply !== null && reply !== undefined) {
       const etag = context.request.headers['if-none-match']
 
-      message.headers ??= new Headers()
-
-      if (typeof reply === 'object' && '_version' in reply)
-        if (etag !== undefined && reply._version === this.version(etag)) {
-          message.status = 304
-          message.headers.set('etag', etag)
-
-          return message
-        } else
-          message.headers.set('etag', `"${reply._version.toString()}"`)
-      else if (!(reply instanceof Readable)) {
-        const hash = `"${createHash('sha256').update(JSON.stringify(reply)).digest('hex')}"`
-
-        if (etag === hash) {
-          message.status = 304
-          message.headers.set('etag', etag)
-
-          return message
-        } else
-          message.headers.set('etag', hash)
-      }
+      if (this.conditionalGet(reply, etag, message))
+        return message
     }
 
     // last-modified
@@ -122,6 +103,41 @@ export class Endpoint implements RTD.Endpoint {
     await this.remote.disconnect(INTERRUPT)
   }
 
+  private conditionalGet (reply: unknown, etag: string | undefined, message: http.OutgoingMessage): boolean {
+    message.headers ??= new Headers()
+
+    if (typeof reply === 'object' && reply !== null && '_version' in reply) {
+      const matched = etag === undefined ? null : this.matchVersion(etag)
+
+      if (etag !== undefined && matched !== null && reply._version === matched) {
+        message.status = 304
+        message.headers.set('etag', etag)
+
+        return true
+      }
+
+      message.headers.set('etag', `"${reply._version.toString()}"`)
+
+      return false
+    }
+
+    if (reply instanceof Readable)
+      return false
+
+    const hash = `"${createHash('sha256').update(JSON.stringify(reply)).digest('hex')}"`
+
+    if (etag === hash) {
+      message.status = 304
+      message.headers.set('etag', etag)
+
+      return true
+    }
+
+    message.headers.set('etag', hash)
+
+    return false
+  }
+
   private query (context: http.Context): http.Query {
     const query: http.Query = Object.fromEntries(context.url.searchParams)
     const etag = context.request.headers['if-match']
@@ -132,13 +148,22 @@ export class Endpoint implements RTD.Endpoint {
     return query
   }
 
-  private version (etag: string): number {
+  private matchVersion (etag: string): number | null {
     const match = etag.match(ETAG)
 
     if (match === null)
-      throw new http.BadRequest('Invalid ETag')
+      return null
 
     return Number.parseInt(match.groups!.version)
+  }
+
+  private version (etag: string): number {
+    const version = this.matchVersion(etag)
+
+    if (version === null)
+      throw new http.BadRequest('Invalid ETag')
+
+    return version
   }
 }
 


### PR DESCRIPTION
## Summary
- Accept hash ETags in `if-none-match` on versioned resources without `400 Invalid ETag`
- Keep strict numeric ETag parsing for `if-match` / optimistic concurrency

## Test plan
- [x] Cucumber scenario `Hash if-none-match on versioned resource`
- [x] CodeQL on push to `dev`


Made with [Cursor](https://cursor.com)