### PR TITLE
fix(exposition): stop reconcile ping flood and honor log level

### DIFF
--- a/extensions/exposition/features/dynamic.feature
+++ b/extensions/exposition/features/dynamic.feature
@@ -84,7 +84,7 @@ Feature: Dynamic tree updates
       """
 
   Scenario: Stale branch expires
-    Given the branch TTL is 0.5 seconds
+    Given the branch TTL is 5 seconds
     And the Gateway is running
     And the `pots` is running with the following manifest:
       """yaml
@@ -104,7 +104,7 @@ Feature: Dynamic tree updates
       200 OK
       """
     Then the `pots` is stopped
-    And after 0.8 seconds
+    And after 6 seconds
     When the following request is received:
       """
       GET /pots/ HTTP/1.1

--- a/extensions/exposition/source/Factory.ts
+++ b/extensions/exposition/source/Factory.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert'
 import { createHash } from 'node:crypto'
+import { console } from 'openspan'
 import { decode } from '@toa.io/generic'
 import { Tenant } from './Tenant'
 import { Gateway } from './Gateway'
@@ -16,6 +17,7 @@ import type { Branch } from './Branch'
 import type { syntax } from './RTD'
 import type { Broadcast } from './Gateway'
 import type { Connector, Locator, extensions } from '@toa.io/core'
+import type { Channel } from 'openspan'
 
 export class Factory implements extensions.Factory {
   private readonly boot: Bootloader
@@ -43,6 +45,8 @@ export class Factory implements extensions.Factory {
     assert.ok(process.env.TOA_EXPOSITION_PROPERTIES,
       'TOA_EXPOSITION_PROPERTIES is undefined')
 
+    configureLogs()
+
     const options = decode<http.Options>(process.env.TOA_EXPOSITION_PROPERTIES)
     const broadcast: Broadcast = this.boot.bindings.broadcast(CHANNEL)
     const server = http.Server.create({ ...options })
@@ -67,6 +71,15 @@ export class Factory implements extensions.Factory {
 }
 
 const CHANNEL = 'exposition'
+const LOGS_PREFIX = 'TOA_TELEMETRY_LOGS'
+
+function configureLogs (): void {
+  const globEnv = process.env[LOGS_PREFIX]
+  const level: Channel = process.env.TOA_DEV === '1' ? 'debug' : 'info'
+  const options = globEnv === undefined ? { level } : decode<{ level?: Channel }>(globEnv)
+
+  console.configure({ level: options.level ?? level })
+}
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export type Bootloader = typeof import('@toa.io/boot')

--- a/extensions/exposition/source/Gateway.ts
+++ b/extensions/exposition/source/Gateway.ts
@@ -17,7 +17,6 @@ export class Gateway extends Connector {
   private lastMerge = 0
   private lastPing = 0
   private stopped = false
-  private reconciliation: NodeJS.Timeout | null = null
   private resolveFirstMerge: (() => void) | null = null
 
   public constructor (broadcast: Broadcast, tree: Tree, interception: Interception) {
@@ -72,9 +71,6 @@ export class Gateway extends Connector {
 
   protected override dispose (): void {
     this.stopped = true
-
-    if (this.reconciliation !== null)
-      clearInterval(this.reconciliation)
 
     this.tree.dispose()
 
@@ -143,9 +139,6 @@ export class Gateway extends Connector {
     void this.knock()
 
     await this.settled(first)
-
-    this.reconciliation = setInterval(() => void this.ping(), RECONCILE_INTERVAL)
-    this.reconciliation.unref()
   }
 
   /**
@@ -252,5 +245,4 @@ const SETTLE_QUIET = 10_000
 const SETTLE_TIMEOUT = 30_000
 const SETTLE_POLL = 50
 const KNOCK_DELAYS = [0, 500, 1000, 1500]
-const RECONCILE_INTERVAL = 30_000
 const PING_COOLDOWN = 5_000

--- a/extensions/exposition/source/Tenant.ts
+++ b/extensions/exposition/source/Tenant.ts
@@ -1,5 +1,6 @@
 import { setTimeout } from 'node:timers/promises'
 import { Connector } from '@toa.io/core'
+import { BRANCH_TTL } from './const'
 import type { bindings } from '@toa.io/core'
 import type { Label } from './discovery'
 import type { Branch } from './Branch'
@@ -55,9 +56,7 @@ function exposeInterval (uptime: number): number {
 }
 
 const EXPOSE_MIN = 5_000
-
-// a refresh no longer rebuilds the branch, so exposing often is cheap
-const EXPOSE_MAX = 120_000
+const EXPOSE_MAX = Math.round(BRANCH_TTL / 2.1)
 const EXPOSE_TAU = 900_000
 
 type Broadcast = bindings.Broadcast<Label>


### PR DESCRIPTION
## Summary
- Remove the gateway's 30s reconcile ping; keep startup knock and 404 reping so tenants own exponential re-expose under branch TTL
- Restore `EXPOSE_MAX = BRANCH_TTL / 2.1` (~14.3m) instead of the 2m cap that flooded discovery
- Configure the gateway's local openspan from `TOA_TELEMETRY_LOGS` so production `info` actually filters `Branch refreshed` DEBUG
- Widen the stale-branch cucumber timings so the scenario is stable

## Test plan
- [x] `npx cucumber-js features/dynamic.feature --name "Stale branch expires"` ×3 consecutive passes
- [ ] Confirm production gateway no longer emits DEBUG `Branch refreshed` every ~15s after deploy


Made with [Cursor](https://cursor.com)